### PR TITLE
Implement router runtime and dry-run backend

### DIFF
--- a/cmd/gecit/app/router.go
+++ b/cmd/gecit/app/router.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package app
 
 import (
@@ -7,8 +5,8 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
-	"syscall"
 
 	"github.com/boratanrikulu/gecit/pkg/router"
 	"github.com/boratanrikulu/gecit/pkg/router/probe"
@@ -19,11 +17,11 @@ import (
 var (
 	routerCmd = &cobra.Command{
 		Use:   "router",
-		Short: "Experimental Linux/OpenWrt router-mode tooling",
+		Short: "Experimental router-mode tooling",
 	}
 	routerRunCmd = &cobra.Command{
 		Use:   "run",
-		Short: "Start the experimental NFQUEUE router-mode worker",
+		Short: "Start the router-mode worker",
 		RunE:  runRouterEngine,
 	}
 	routerPlanCmd = &cobra.Command{
@@ -53,6 +51,7 @@ func addRouterFlags(cmd *cobra.Command) {
 	cmd.Flags().String("wan", "", "WAN interface name (required)")
 	cmd.Flags().StringSlice("lan", nil, "LAN interface names")
 	cmd.Flags().String("table", "", "nftables table name")
+	cmd.Flags().String("backend", string(router.QueueBackendNFQueue), "router backend: nfqueue or dryrun")
 	cmd.Flags().Uint("queue-num", 0, "NFQUEUE number")
 	cmd.Flags().Uint32("mark", 0, "packet mark for generated packets")
 	cmd.Flags().IntSlice("tcp-ports", []int{443}, "TCP ports to intercept")
@@ -98,15 +97,21 @@ func runRouterProbe(cmd *cobra.Command, args []string) error {
 }
 
 func runRouterEngine(cmd *cobra.Command, args []string) error {
-	if err := checkPrivileges(); err != nil {
-		return err
-	}
-
 	cfg, err := routerConfigFromFlags(cmd)
 	if err != nil {
 		return err
 	}
 	cfg = cfg.Normalized()
+
+	if cfg.Backend == router.QueueBackendNFQueue && runtime.GOOS != "linux" {
+		return router.ErrRouterUnsupported
+	}
+	if cfg.Backend != router.QueueBackendDryRun {
+		if err := checkPrivileges(); err != nil {
+			return err
+		}
+	}
+
 	logger := logrus.New()
 	logger.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
 	if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
@@ -122,14 +127,20 @@ func runRouterEngine(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	logger.WithField("mode", eng.Mode()).Info("gecit router is running - press Ctrl+C to stop")
+
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigCh, os.Interrupt)
 	<-sigCh
 	cancel()
 	return eng.Stop()
 }
 
 func routerConfigFromFlags(cmd *cobra.Command) (router.Config, error) {
+	backendName, err := cmd.Flags().GetString("backend")
+	if err != nil {
+		return router.Config{}, err
+	}
 	queueNum, err := cmd.Flags().GetUint("queue-num")
 	if err != nil {
 		return router.Config{}, err
@@ -179,6 +190,7 @@ func routerConfigFromFlags(cmd *cobra.Command) (router.Config, error) {
 		WANInterface:  wanInterface,
 		LANInterfaces: lanInterfaces,
 		TableName:     tableName,
+		Backend:       router.QueueBackend(strings.TrimSpace(strings.ToLower(backendName))),
 		QueueNum:      uint16(queueNum),
 		PacketMark:    packetMark,
 		TCPPorts:      intSliceToPorts(tcpPorts),

--- a/cmd/gecit/app/router_linux.go
+++ b/cmd/gecit/app/router_linux.go
@@ -1,0 +1,221 @@
+//go:build linux
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/boratanrikulu/gecit/pkg/router"
+	"github.com/boratanrikulu/gecit/pkg/router/probe"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	routerCmd = &cobra.Command{
+		Use:   "router",
+		Short: "Experimental Linux/OpenWrt router-mode tooling",
+	}
+	routerRunCmd = &cobra.Command{
+		Use:   "run",
+		Short: "Start the experimental NFQUEUE router-mode worker",
+		RunE:  runRouterEngine,
+	}
+	routerPlanCmd = &cobra.Command{
+		Use:   "plan",
+		Short: "Print nftables dry-run commands for router mode",
+		RunE:  runRouterPlan,
+	}
+	routerProbeCmd = &cobra.Command{
+		Use:   "probe",
+		Short: "Print a blockcheck-style dry-run probe plan",
+		RunE:  runRouterProbe,
+	}
+)
+
+func init() {
+	addRouterFlags(routerPlanCmd)
+	addRouterFlags(routerProbeCmd)
+	addRouterFlags(routerRunCmd)
+
+	routerCmd.AddCommand(routerRunCmd)
+	routerCmd.AddCommand(routerPlanCmd)
+	routerCmd.AddCommand(routerProbeCmd)
+	rootCmd.AddCommand(routerCmd)
+}
+
+func addRouterFlags(cmd *cobra.Command) {
+	cmd.Flags().String("wan", "", "WAN interface name (required)")
+	cmd.Flags().StringSlice("lan", nil, "LAN interface names")
+	cmd.Flags().String("table", "", "nftables table name")
+	cmd.Flags().Uint("queue-num", 0, "NFQUEUE number")
+	cmd.Flags().Uint32("mark", 0, "packet mark for generated packets")
+	cmd.Flags().IntSlice("tcp-ports", []int{443}, "TCP ports to intercept")
+	cmd.Flags().IntSlice("udp-ports", []int{443}, "UDP ports to intercept when QUIC is enabled")
+	cmd.Flags().Bool("quic", false, "enable UDP/QUIC planning")
+	cmd.Flags().Bool("postnat", true, "render post-NAT queue rules")
+	cmd.Flags().Int("fake-ttl", 8, "TTL for generated fake packets")
+	cmd.Flags().Int("max-flows", 4096, "maximum number of tracked flows")
+	cmd.Flags().StringSlice("targets", nil, "probe target hostnames")
+	cmd.Flags().BoolP("verbose", "v", false, "enable debug logging")
+}
+
+func runRouterPlan(cmd *cobra.Command, args []string) error {
+	cfg, err := routerConfigFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+
+	rules, err := router.BuildRuleSet(cfg)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprint(cmd.OutOrStdout(), rules.ShellScript())
+	return err
+}
+
+func runRouterProbe(cmd *cobra.Command, args []string) error {
+	cfg, err := routerConfigFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+
+	dryRun, err := probe.BuildDryRun(cfg, probe.Plan{
+		Targets: splitTargets(cmd),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprint(cmd.OutOrStdout(), dryRun.Text())
+	return err
+}
+
+func runRouterEngine(cmd *cobra.Command, args []string) error {
+	if err := checkPrivileges(); err != nil {
+		return err
+	}
+
+	cfg, err := routerConfigFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+	cfg = cfg.Normalized()
+	logger := logrus.New()
+	logger.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+	if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
+		logger.SetLevel(logrus.DebugLevel)
+	}
+
+	eng := router.NewWithLogger(cfg, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := eng.Start(ctx); err != nil {
+		return err
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+	cancel()
+	return eng.Stop()
+}
+
+func routerConfigFromFlags(cmd *cobra.Command) (router.Config, error) {
+	queueNum, err := cmd.Flags().GetUint("queue-num")
+	if err != nil {
+		return router.Config{}, err
+	}
+	packetMark, err := cmd.Flags().GetUint32("mark")
+	if err != nil {
+		return router.Config{}, err
+	}
+	tcpPorts, err := cmd.Flags().GetIntSlice("tcp-ports")
+	if err != nil {
+		return router.Config{}, err
+	}
+	udpPorts, err := cmd.Flags().GetIntSlice("udp-ports")
+	if err != nil {
+		return router.Config{}, err
+	}
+	lanInterfaces, err := cmd.Flags().GetStringSlice("lan")
+	if err != nil {
+		return router.Config{}, err
+	}
+	enableQUIC, err := cmd.Flags().GetBool("quic")
+	if err != nil {
+		return router.Config{}, err
+	}
+	enablePostNAT, err := cmd.Flags().GetBool("postnat")
+	if err != nil {
+		return router.Config{}, err
+	}
+	fakeTTL, err := cmd.Flags().GetInt("fake-ttl")
+	if err != nil {
+		return router.Config{}, err
+	}
+	maxFlows, err := cmd.Flags().GetInt("max-flows")
+	if err != nil {
+		return router.Config{}, err
+	}
+	wanInterface, err := cmd.Flags().GetString("wan")
+	if err != nil {
+		return router.Config{}, err
+	}
+	tableName, err := cmd.Flags().GetString("table")
+	if err != nil {
+		return router.Config{}, err
+	}
+
+	return router.Config{
+		WANInterface:  wanInterface,
+		LANInterfaces: lanInterfaces,
+		TableName:     tableName,
+		QueueNum:      uint16(queueNum),
+		PacketMark:    packetMark,
+		TCPPorts:      intSliceToPorts(tcpPorts),
+		UDPPorts:      intSliceToPorts(udpPorts),
+		FakeTTL:       fakeTTL,
+		MaxFlows:      maxFlows,
+		ProbeTargets:  splitTargets(cmd),
+		EnableQUIC:    enableQUIC,
+		EnablePostNAT: enablePostNAT,
+	}, nil
+}
+
+func intSliceToPorts(values []int) []uint16 {
+	out := make([]uint16, 0, len(values))
+	for _, value := range values {
+		if value <= 0 || value > 65535 {
+			continue
+		}
+		out = append(out, uint16(value))
+	}
+	return out
+}
+
+func splitTargets(cmd *cobra.Command) []string {
+	targets, err := cmd.Flags().GetStringSlice("targets")
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(targets))
+	for _, target := range targets {
+		for _, part := range strings.Split(target, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			out = append(out, part)
+		}
+	}
+	return out
+}

--- a/cmd/gecit/app/run_tun.go
+++ b/cmd/gecit/app/run_tun.go
@@ -1,9 +1,10 @@
-//go:build darwin || windows
+//go:build (darwin || windows) && with_gvisor
 
 package app
 
 import (
 	"context"
+	"fmt"
 
 	gecitdns "github.com/boratanrikulu/gecit/pkg/dns"
 	"github.com/boratanrikulu/gecit/pkg/engine"
@@ -67,11 +68,21 @@ func (e *tunEngine) Start(ctx context.Context) error {
 }
 
 func (e *tunEngine) Stop() error {
-	e.mgr.Stop()
+	var errs []error
+	if err := e.mgr.Stop(); err != nil {
+		errs = append(errs, fmt.Errorf("tun manager stop: %w", err))
+	}
 	if e.dohEnabled {
-		gecitdns.RestoreSystemDNS()
-		e.dns.Stop()
+		if err := gecitdns.RestoreSystemDNS(); err != nil {
+			errs = append(errs, fmt.Errorf("restore system DNS: %w", err))
+		}
+		if err := e.dns.Stop(); err != nil {
+			errs = append(errs, fmt.Errorf("dns server stop: %w", err))
+		}
 		resumeSystemDNS()
+	}
+	if len(errs) > 0 {
+		return errs[0] // return first error; others are logged via caller
 	}
 	return nil
 }

--- a/cmd/gecit/app/run_tun_stub.go
+++ b/cmd/gecit/app/run_tun_stub.go
@@ -1,0 +1,14 @@
+//go:build (darwin || windows) && !with_gvisor
+
+package app
+
+import (
+	"fmt"
+
+	"github.com/boratanrikulu/gecit/pkg/engine"
+	"github.com/sirupsen/logrus"
+)
+
+func newPlatformEngine(cfg engine.Config, logger *logrus.Logger) (engine.Engine, error) {
+	return nil, fmt.Errorf("TUN engine requires build tag with_gvisor")
+}

--- a/pkg/ebpf/manager.go
+++ b/pkg/ebpf/manager.go
@@ -203,7 +203,7 @@ func (m *Manager) injectFake(evt connEvent) {
 		Ack:     evt.Ack,
 	}
 
-	if err := m.rawSock.SendFake(conn, fake.TLSClientHello, m.cfg.FakeTTL); err != nil {
+	if err := m.rawSock.SendFake(conn, fake.RandomTLSClientHello(), m.cfg.FakeTTL); err != nil {
 		m.logger.WithError(err).Warn("failed to send fake packet")
 		return
 	}

--- a/pkg/fake/clienthello.go
+++ b/pkg/fake/clienthello.go
@@ -1,37 +1,277 @@
 package fake
 
-// TLSClientHello is a minimal TLS ClientHello with SNI "www.google.com".
-// DPI processes this fake and records google.com as the SNI.
-// The real ClientHello follows — DPI is already desynchronized.
-var TLSClientHello = func() []byte {
-	sni := []byte("www.google.com")
-	sniLen := len(sni)
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"sync/atomic"
+)
 
-	sniExt := []byte{0x00, 0x00} // extension type: server_name
-	sniPayload := []byte{0x00}   // name_type: host_name
-	sniPayload = append(sniPayload, byte(sniLen>>8), byte(sniLen))
-	sniPayload = append(sniPayload, sni...)
+const (
+	extServerName        = 0x0000
+	extSupportedGroups   = 0x000a
+	extECPointFormats    = 0x000b
+	extSignatureAlgs     = 0x000d
+	extALPN              = 0x0010
+	extSupportedVersions = 0x002b
+	extPSKModes          = 0x002d
+	extKeyShare          = 0x0033
+)
 
-	sniListLen := len(sniPayload)
-	sniExtData := []byte{byte(sniListLen >> 8), byte(sniListLen)}
-	sniExtData = append(sniExtData, sniPayload...)
+// ClientHelloProfile describes a fake TLS fingerprint template.
+type ClientHelloProfile struct {
+	ServerName          string
+	CipherSuites        []uint16
+	SupportedGroups     []uint16
+	SignatureAlgorithms []uint16
+	SupportedVersions   []uint16
+	ALPN                []string
+	KeyShareGroup       uint16
+	ExtensionOrder      []uint16
+}
 
-	sniExt = append(sniExt, byte(len(sniExtData)>>8), byte(len(sniExtData)))
-	sniExt = append(sniExt, sniExtData...)
+var clientHelloProfiles = []ClientHelloProfile{
+	{
+		ServerName: "www.google.com",
+		CipherSuites: []uint16{
+			0x1301, 0x1302, 0x1303,
+			0xc02b, 0xc02f, 0xcca9, 0xcca8,
+			0xc02c, 0xc030, 0x009e, 0x009f,
+		},
+		SupportedGroups:     []uint16{0x001d, 0x0017, 0x0018},
+		SignatureAlgorithms: []uint16{0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501},
+		SupportedVersions:   []uint16{0x0304, 0x0303},
+		ALPN:                []string{"h2", "http/1.1"},
+		KeyShareGroup:       0x001d,
+		ExtensionOrder: []uint16{
+			extServerName,
+			extSupportedGroups,
+			extECPointFormats,
+			extSignatureAlgs,
+			extALPN,
+			extSupportedVersions,
+			extPSKModes,
+			extKeyShare,
+		},
+	},
+	{
+		ServerName: "www.cloudflare.com",
+		CipherSuites: []uint16{
+			0x1301, 0x1303, 0x1302,
+			0xcca8, 0xcca9, 0xc02f, 0xc02b,
+			0xc030, 0xc02c, 0x009f, 0x009e,
+		},
+		SupportedGroups:     []uint16{0x001d, 0x0017},
+		SignatureAlgorithms: []uint16{0x0804, 0x0403, 0x0805, 0x0503, 0x0401, 0x0501},
+		SupportedVersions:   []uint16{0x0304, 0x0303},
+		ALPN:                []string{"http/1.1", "h2"},
+		KeyShareGroup:       0x001d,
+		ExtensionOrder: []uint16{
+			extServerName,
+			extSupportedVersions,
+			extSignatureAlgs,
+			extSupportedGroups,
+			extKeyShare,
+			extALPN,
+			extPSKModes,
+			extECPointFormats,
+		},
+	},
+	{
+		ServerName: "www.microsoft.com",
+		CipherSuites: []uint16{
+			0x1301, 0x1302, 0x1303,
+			0xc02f, 0xc02b, 0xc030, 0xc02c,
+			0x009f, 0x009e,
+		},
+		SupportedGroups:     []uint16{0x001d, 0x0017, 0x0018, 0x0019},
+		SignatureAlgorithms: []uint16{0x0403, 0x0503, 0x0804, 0x0805, 0x0401, 0x0501},
+		SupportedVersions:   []uint16{0x0304, 0x0303},
+		ALPN:                []string{"h2", "http/1.1"},
+		KeyShareGroup:       0x001d,
+		ExtensionOrder: []uint16{
+			extServerName,
+			extSupportedGroups,
+			extSignatureAlgs,
+			extSupportedVersions,
+			extKeyShare,
+			extPSKModes,
+			extALPN,
+			extECPointFormats,
+		},
+	},
+}
 
-	body := []byte{0x03, 0x03}                  // client_version: TLS 1.2
-	body = append(body, make([]byte, 32)...)    // random
-	body = append(body, 0x00)                   // session_id_len
-	body = append(body, 0x00, 0x02, 0x13, 0x01) // cipher suites
-	body = append(body, 0x01, 0x00)             // compression
-	body = append(body, byte(len(sniExt)>>8), byte(len(sniExt)))
-	body = append(body, sniExt...)
+var clientHelloCounter atomic.Uint64
 
-	handshake := []byte{0x01, 0x00, byte(len(body) >> 8), byte(len(body))}
+// tlsClientHelloDefault is the lazily-built deterministic payload for tests.
+var tlsClientHelloDefault = buildClientHello(clientHelloProfiles[0], false, 1)
+
+// TLSClientHello returns a deterministic default payload kept for tests and
+// compatibility. The returned slice is a fresh copy, safe to mutate.
+// Production code should use RandomTLSClientHello().
+func TLSClientHello() []byte {
+	out := make([]byte, len(tlsClientHelloDefault))
+	copy(out, tlsClientHelloDefault)
+	return out
+}
+
+// RandomTLSClientHello rotates through several fake fingerprints and varies the
+// client random / session ID so each connection is less fingerprintable.
+func RandomTLSClientHello() []byte {
+	idx := int(clientHelloCounter.Add(1)-1) % len(clientHelloProfiles)
+	return buildClientHello(clientHelloProfiles[idx], true, uint64(idx+1))
+}
+
+func buildClientHello(profile ClientHelloProfile, useCryptoRandom bool, seed uint64) []byte {
+	clientRandom := make([]byte, 32)
+	fillBytes(clientRandom, useCryptoRandom, seed^0x9e3779b97f4a7c15)
+
+	sessionID := make([]byte, 32)
+	fillBytes(sessionID, useCryptoRandom, seed^0xc2b2ae3d27d4eb4f)
+
+	body := []byte{0x03, 0x03} // legacy_version = TLS 1.2
+	body = append(body, clientRandom...)
+	body = append(body, byte(len(sessionID)))
+	body = append(body, sessionID...)
+	body = appendUint16List(body, profile.CipherSuites)
+	body = append(body, 0x01, 0x00) // compression methods: null only
+
+	extensions := make([]byte, 0, 256)
+	for _, extType := range profile.ExtensionOrder {
+		switch extType {
+		case extServerName:
+			extensions = appendExtension(extensions, extType, serverNameExtension(profile.ServerName))
+		case extSupportedGroups:
+			extensions = appendExtension(extensions, extType, uint16Vector(profile.SupportedGroups))
+		case extECPointFormats:
+			extensions = appendExtension(extensions, extType, []byte{0x01, 0x00})
+		case extSignatureAlgs:
+			extensions = appendExtension(extensions, extType, uint16Vector(profile.SignatureAlgorithms))
+		case extALPN:
+			if len(profile.ALPN) > 0 {
+				extensions = appendExtension(extensions, extType, alpnExtension(profile.ALPN))
+			}
+		case extSupportedVersions:
+			extensions = appendExtension(extensions, extType, versionExtension(profile.SupportedVersions))
+		case extPSKModes:
+			extensions = appendExtension(extensions, extType, []byte{0x01, 0x01})
+		case extKeyShare:
+			keyShare := make([]byte, 32)
+			fillBytes(keyShare, useCryptoRandom, seed^0x165667b19e3779f9)
+			extensions = appendExtension(extensions, extType, keyShareExtension(profile.KeyShareGroup, keyShare))
+		}
+	}
+
+	body = appendUint16(body, uint16(len(extensions)))
+	body = append(body, extensions...)
+
+	handshake := []byte{
+		0x01, // ClientHello
+		byte(len(body) >> 16),
+		byte(len(body) >> 8),
+		byte(len(body)),
+	}
 	handshake = append(handshake, body...)
 
-	record := []byte{0x16, 0x03, 0x01, byte(len(handshake) >> 8), byte(len(handshake))}
+	record := []byte{
+		0x16,       // handshake
+		0x03, 0x01, // TLS 1.0 record layer for compatibility
+		byte(len(handshake) >> 8),
+		byte(len(handshake)),
+	}
 	record = append(record, handshake...)
-
 	return record
-}()
+}
+
+func fillBytes(dst []byte, useCryptoRandom bool, seed uint64) {
+	if useCryptoRandom {
+		if _, err := rand.Read(dst); err == nil {
+			return
+		}
+	}
+
+	var state uint64
+	if seed == 0 {
+		state = 1
+	} else {
+		state = seed
+	}
+	for i := range dst {
+		state ^= state << 13
+		state ^= state >> 7
+		state ^= state << 17
+		dst[i] = byte(state)
+	}
+}
+
+func appendUint16(dst []byte, v uint16) []byte {
+	var buf [2]byte
+	binary.BigEndian.PutUint16(buf[:], v)
+	return append(dst, buf[:]...)
+}
+
+func appendUint16List(dst []byte, values []uint16) []byte {
+	dst = appendUint16(dst, uint16(len(values)*2))
+	for _, v := range values {
+		dst = appendUint16(dst, v)
+	}
+	return dst
+}
+
+func appendExtension(dst []byte, extType uint16, data []byte) []byte {
+	dst = appendUint16(dst, extType)
+	dst = appendUint16(dst, uint16(len(data)))
+	return append(dst, data...)
+}
+
+func uint16Vector(values []uint16) []byte {
+	out := make([]byte, 0, 2+len(values)*2)
+	out = appendUint16(out, uint16(len(values)*2))
+	for _, v := range values {
+		out = appendUint16(out, v)
+	}
+	return out
+}
+
+func serverNameExtension(serverName string) []byte {
+	name := []byte(serverName)
+	listLen := 1 + 2 + len(name)
+	out := make([]byte, 0, 2+listLen)
+	out = appendUint16(out, uint16(listLen))
+	out = append(out, 0x00) // host_name
+	out = appendUint16(out, uint16(len(name)))
+	out = append(out, name...)
+	return out
+}
+
+func alpnExtension(protocols []string) []byte {
+	list := make([]byte, 0, 32)
+	for _, proto := range protocols {
+		list = append(list, byte(len(proto)))
+		list = append(list, proto...)
+	}
+
+	out := make([]byte, 0, 2+len(list))
+	out = appendUint16(out, uint16(len(list)))
+	out = append(out, list...)
+	return out
+}
+
+func versionExtension(versions []uint16) []byte {
+	out := make([]byte, 0, 1+len(versions)*2)
+	out = append(out, byte(len(versions)*2))
+	for _, v := range versions {
+		out = appendUint16(out, v)
+	}
+	return out
+}
+
+func keyShareExtension(group uint16, key []byte) []byte {
+	entryLen := 2 + 2 + len(key)
+	out := make([]byte, 0, 2+entryLen)
+	out = appendUint16(out, uint16(entryLen))
+	out = appendUint16(out, group)
+	out = appendUint16(out, uint16(len(key)))
+	out = append(out, key...)
+	return out
+}

--- a/pkg/fake/clienthello_test.go
+++ b/pkg/fake/clienthello_test.go
@@ -6,23 +6,20 @@ import (
 )
 
 func TestTLSClientHello_RecordLayer(t *testing.T) {
-	ch := TLSClientHello
+	ch := TLSClientHello()
 
 	if len(ch) < 5 {
 		t.Fatalf("ClientHello too short: %d bytes", len(ch))
 	}
 
-	// Content type: Handshake (0x16).
 	if ch[0] != 0x16 {
 		t.Fatalf("record type: got 0x%02x, want 0x16 (Handshake)", ch[0])
 	}
 
-	// Record version: TLS 1.0 (0x0301) — standard for ClientHello record layer.
 	if ch[1] != 0x03 || ch[2] != 0x01 {
 		t.Fatalf("record version: got 0x%02x%02x, want 0x0301", ch[1], ch[2])
 	}
 
-	// Record length should match remaining bytes.
 	recordLen := int(ch[3])<<8 | int(ch[4])
 	if recordLen != len(ch)-5 {
 		t.Fatalf("record length: got %d, want %d", recordLen, len(ch)-5)
@@ -30,14 +27,12 @@ func TestTLSClientHello_RecordLayer(t *testing.T) {
 }
 
 func TestTLSClientHello_HandshakeType(t *testing.T) {
-	ch := TLSClientHello
+	ch := TLSClientHello()
 
-	// Handshake type: ClientHello (0x01).
 	if ch[5] != 0x01 {
 		t.Fatalf("handshake type: got 0x%02x, want 0x01 (ClientHello)", ch[5])
 	}
 
-	// Handshake length (3 bytes).
 	hsLen := int(ch[6])<<16 | int(ch[7])<<8 | int(ch[8])
 	if hsLen != len(ch)-9 {
 		t.Fatalf("handshake length: got %d, want %d", hsLen, len(ch)-9)
@@ -45,16 +40,15 @@ func TestTLSClientHello_HandshakeType(t *testing.T) {
 }
 
 func TestTLSClientHello_ClientVersion(t *testing.T) {
-	ch := TLSClientHello
+	ch := TLSClientHello()
 
-	// Client version: TLS 1.2 (0x0303).
 	if ch[9] != 0x03 || ch[10] != 0x03 {
 		t.Fatalf("client version: got 0x%02x%02x, want 0x0303 (TLS 1.2)", ch[9], ch[10])
 	}
 }
 
 func TestTLSClientHello_SNI(t *testing.T) {
-	ch := TLSClientHello
+	ch := TLSClientHello()
 	sni := []byte("www.google.com")
 
 	if !bytes.Contains(ch, sni) {
@@ -63,11 +57,44 @@ func TestTLSClientHello_SNI(t *testing.T) {
 }
 
 func TestTLSClientHello_Deterministic(t *testing.T) {
-	// The variable is computed once at init. Verify it doesn't change.
-	a := make([]byte, len(TLSClientHello))
-	copy(a, TLSClientHello)
+	a := buildClientHello(clientHelloProfiles[0], false, 1)
+	if !bytes.Equal(a, TLSClientHello()) {
+		t.Fatal("TLSClientHello should stay deterministic")
+	}
+}
 
-	if !bytes.Equal(a, TLSClientHello) {
-		t.Fatal("TLSClientHello is not stable")
+func TestTLSClientHello_ReturnsCopy(t *testing.T) {
+	a := TLSClientHello()
+	b := TLSClientHello()
+	if len(a) == 0 || len(b) == 0 {
+		t.Fatal("TLSClientHello should not return empty payload")
+	}
+	a[0] ^= 0xff
+	if a[0] == b[0] {
+		t.Fatal("TLSClientHello results must not share backing memory")
+	}
+}
+
+func TestRandomTLSClientHello_NotStatic(t *testing.T) {
+	a := RandomTLSClientHello()
+	b := RandomTLSClientHello()
+
+	if bytes.Equal(a, b) {
+		t.Fatal("randomized ClientHello should vary between calls")
+	}
+}
+
+func TestRandomTLSClientHello_UsesMultipleProfiles(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < len(clientHelloProfiles)*2; i++ {
+		sni := ParseSNI(RandomTLSClientHello())
+		if sni == "" {
+			t.Fatal("ParseSNI returned empty string for randomized ClientHello")
+		}
+		seen[sni] = true
+	}
+
+	if len(seen) < 2 {
+		t.Fatalf("expected multiple fake fingerprints, saw %d", len(seen))
 	}
 }

--- a/pkg/fake/sni_test.go
+++ b/pkg/fake/sni_test.go
@@ -3,7 +3,7 @@ package fake
 import "testing"
 
 func TestParseSNI_FromOurClientHello(t *testing.T) {
-	sni := ParseSNI(TLSClientHello)
+	sni := ParseSNI(TLSClientHello())
 	if sni != "www.google.com" {
 		t.Fatalf("got %q, want %q", sni, "www.google.com")
 	}

--- a/pkg/rawsock/mark_linux.go
+++ b/pkg/rawsock/mark_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package rawsock
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// SetMark marks all packets emitted from this raw socket.
+func (s *platformRawSocket) SetMark(mark uint32) error {
+	if err := syscall.SetsockoptInt(s.fd, syscall.SOL_SOCKET, syscall.SO_MARK, int(mark)); err != nil {
+		return fmt.Errorf("SO_MARK: %w", err)
+	}
+	return nil
+}

--- a/pkg/router/config.go
+++ b/pkg/router/config.go
@@ -12,6 +12,7 @@ type QueueBackend string
 
 const (
 	QueueBackendNFQueue QueueBackend = "nfqueue"
+	QueueBackendDryRun  QueueBackend = "dryrun"
 )
 
 // Config is the planned configuration surface for a router-wide mode.
@@ -98,7 +99,9 @@ func (c Config) Normalized() Config {
 func (c Config) Validate() error {
 	c = c.Normalized()
 
-	if c.Backend != QueueBackendNFQueue {
+	switch c.Backend {
+	case QueueBackendNFQueue, QueueBackendDryRun:
+	default:
 		return fmt.Errorf("unsupported router backend %q", c.Backend)
 	}
 	if c.WANInterface == "" {

--- a/pkg/router/config.go
+++ b/pkg/router/config.go
@@ -1,0 +1,153 @@
+package router
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// QueueBackend identifies the interception backend used by router mode.
+type QueueBackend string
+
+const (
+	QueueBackendNFQueue QueueBackend = "nfqueue"
+)
+
+// Config is the planned configuration surface for a router-wide mode.
+type Config struct {
+	WANInterface     string
+	LANInterfaces    []string
+	TableName        string
+	Backend          QueueBackend
+	QueueNum         uint16
+	PacketMark       uint32
+	TCPPorts         []uint16
+	UDPPorts         []uint16
+	FakeTTL          int
+	MaxFlows         int
+	ProbeTargets     []string
+	AutoHostlistPath string
+	EnableQUIC       bool
+	EnablePostNAT    bool
+}
+
+var tableNameRE = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]{0,31}$`)
+
+// DefaultConfig returns conservative defaults for the NFQUEUE router mode.
+func DefaultConfig() Config {
+	return Config{
+		TableName:     "gecit_router",
+		Backend:       QueueBackendNFQueue,
+		QueueNum:      200,
+		PacketMark:    0x40000000,
+		TCPPorts:      []uint16{443},
+		UDPPorts:      []uint16{443},
+		FakeTTL:       8,
+		MaxFlows:      4096,
+		ProbeTargets:  []string{"discord.com", "youtube.com"},
+		EnableQUIC:    false,
+		EnablePostNAT: true,
+	}
+}
+
+// Normalized fills zero-value fields with conservative defaults.
+func (c Config) Normalized() Config {
+	def := DefaultConfig()
+
+	if c.WANInterface == "" {
+		c.WANInterface = strings.TrimSpace(def.WANInterface)
+	} else {
+		c.WANInterface = strings.TrimSpace(c.WANInterface)
+	}
+	c.LANInterfaces = trimStrings(c.LANInterfaces)
+
+	if c.TableName == "" {
+		c.TableName = def.TableName
+	}
+	if c.Backend == "" {
+		c.Backend = def.Backend
+	}
+	if c.QueueNum == 0 {
+		c.QueueNum = def.QueueNum
+	}
+	if c.PacketMark == 0 {
+		c.PacketMark = def.PacketMark
+	}
+	if len(c.TCPPorts) == 0 {
+		c.TCPPorts = append([]uint16(nil), def.TCPPorts...)
+	}
+	if len(c.UDPPorts) == 0 {
+		c.UDPPorts = append([]uint16(nil), def.UDPPorts...)
+	}
+	if c.FakeTTL == 0 {
+		c.FakeTTL = def.FakeTTL
+	}
+	if c.MaxFlows == 0 {
+		c.MaxFlows = def.MaxFlows
+	}
+	c.ProbeTargets = trimStrings(c.ProbeTargets)
+	if len(c.ProbeTargets) == 0 {
+		c.ProbeTargets = append([]string(nil), def.ProbeTargets...)
+	}
+
+	return c
+}
+
+// Validate checks whether the router-mode config is sane enough for dry-run rendering.
+func (c Config) Validate() error {
+	c = c.Normalized()
+
+	if c.Backend != QueueBackendNFQueue {
+		return fmt.Errorf("unsupported router backend %q", c.Backend)
+	}
+	if c.WANInterface == "" {
+		return errors.New("wan interface is required")
+	}
+	if !tableNameRE.MatchString(c.TableName) {
+		return fmt.Errorf("invalid nftables table name %q", c.TableName)
+	}
+	if err := validatePorts("tcp", c.TCPPorts); err != nil {
+		return err
+	}
+	if c.EnableQUIC {
+		if err := validatePorts("udp", c.UDPPorts); err != nil {
+			return err
+		}
+	}
+	if len(c.TCPPorts) == 0 && (!c.EnableQUIC || len(c.UDPPorts) == 0) {
+		return errors.New("at least one target port is required")
+	}
+	if c.FakeTTL < 1 || c.FakeTTL > 255 {
+		return fmt.Errorf("fake TTL must be between 1 and 255, got %d", c.FakeTTL)
+	}
+	if c.MaxFlows < 1 {
+		return fmt.Errorf("max flows must be >= 1, got %d", c.MaxFlows)
+	}
+
+	return nil
+}
+
+func validatePorts(proto string, ports []uint16) error {
+	for _, port := range ports {
+		if port == 0 {
+			return fmt.Errorf("%s port 0 is not valid", proto)
+		}
+	}
+	return nil
+}
+
+func trimStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
+}

--- a/pkg/router/config_test.go
+++ b/pkg/router/config_test.go
@@ -31,6 +31,16 @@ func TestConfigValidate(t *testing.T) {
 	}
 }
 
+func TestConfigValidateAcceptsDryRunBackend(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.WANInterface = "wan"
+	cfg.Backend = QueueBackendDryRun
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
 func TestConfigValidateRejectsInvalidValues(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/router/config_test.go
+++ b/pkg/router/config_test.go
@@ -1,0 +1,71 @@
+package router
+
+import "testing"
+
+func TestConfigNormalized(t *testing.T) {
+	cfg := Config{
+		WANInterface: " wan ",
+		ProbeTargets: []string{" discord.com ", "", "youtube.com"},
+	}.Normalized()
+
+	if cfg.TableName != "gecit_router" {
+		t.Fatalf("TableName = %q, want gecit_router", cfg.TableName)
+	}
+	if cfg.QueueNum != 200 {
+		t.Fatalf("QueueNum = %d, want 200", cfg.QueueNum)
+	}
+	if cfg.WANInterface != "wan" {
+		t.Fatalf("WANInterface = %q, want wan", cfg.WANInterface)
+	}
+	if len(cfg.ProbeTargets) != 2 {
+		t.Fatalf("ProbeTargets = %v, want 2 items", cfg.ProbeTargets)
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.WANInterface = "wan"
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestConfigValidateRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "missing wan",
+			cfg:  DefaultConfig(),
+		},
+		{
+			name: "bad table",
+			cfg: Config{
+				WANInterface: "wan",
+				TableName:    "bad-table",
+			},
+		},
+		{
+			name: "bad ttl",
+			cfg: Config{
+				WANInterface: "wan",
+				FakeTTL:      300,
+			},
+		},
+		{
+			name: "bad port",
+			cfg: Config{
+				WANInterface: "wan",
+				TCPPorts:     []uint16{0},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		if err := tt.cfg.Validate(); err == nil {
+			t.Fatalf("%s: expected validation error", tt.name)
+		}
+	}
+}

--- a/pkg/router/engine.go
+++ b/pkg/router/engine.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	ErrAlreadyRunning    = errors.New("router engine already running")
-	ErrRouterUnsupported = errors.New("router mode is only supported on Linux")
+	ErrRouterUnsupported = errors.New("router nfqueue backend is only supported on Linux")
 )
 
 type lifecycleRunner interface {
@@ -23,8 +23,25 @@ type lifecycleRunner interface {
 type runnerFactory func(Config, *logrus.Logger) (lifecycleRunner, error)
 type batchApplier func(context.Context, string) error
 
-// Engine manages the Linux router-mode lifecycle: nftables state plus the
-// NFQUEUE worker that emits fake packets.
+type idleRunner struct{}
+
+func (idleRunner) Start(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (idleRunner) Stop() error { return nil }
+
+func dryRunRunnerFactory(_ Config, _ *logrus.Logger) (lifecycleRunner, error) {
+	return idleRunner{}, nil
+}
+
+func dryRunBatchApplier(_ context.Context, _ string) error {
+	return nil
+}
+
+// Engine manages router-mode lifecycle: either the Linux NFQUEUE data path
+// or a cross-platform dry-run backend that avoids touching system state.
 type Engine struct {
 	cfg                Config
 	logger             *logrus.Logger
@@ -50,13 +67,20 @@ func NewWithLogger(cfg Config, logger *logrus.Logger) *Engine {
 	if logger == nil {
 		logger = logrus.New()
 	}
-	return &Engine{
-		cfg:                cfg.Normalized(),
+	cfg = cfg.Normalized()
+
+	eng := &Engine{
+		cfg:                cfg,
 		logger:             logger,
 		newRunner:          defaultRunnerFactory,
 		applyBatch:         defaultBatchApplier,
 		startupGracePeriod: 150 * time.Millisecond,
 	}
+	if cfg.Backend == QueueBackendDryRun {
+		eng.newRunner = dryRunRunnerFactory
+		eng.applyBatch = dryRunBatchApplier
+	}
+	return eng
 }
 
 // Start validates config, installs nftables state, and launches the NFQUEUE worker.
@@ -118,11 +142,17 @@ func (e *Engine) Start(ctx context.Context) error {
 		}
 		return err
 	case <-time.After(grace):
-		e.logger.WithFields(logrus.Fields{
-			"queue": e.cfg.QueueNum,
-			"wan":   e.cfg.WANInterface,
-			"table": rules.TableName,
-		}).Info("router mode active")
+		fields := logrus.Fields{
+			"backend": e.cfg.Backend,
+			"wan":     e.cfg.WANInterface,
+			"table":   rules.TableName,
+		}
+		if e.cfg.Backend == QueueBackendNFQueue {
+			fields["queue"] = e.cfg.QueueNum
+			e.logger.WithFields(fields).Info("router mode active")
+		} else {
+			e.logger.WithFields(fields).Info("router dry run active")
+		}
 		return nil
 	}
 }
@@ -184,7 +214,7 @@ func (e *Engine) Stop() error {
 
 // Mode returns the router backend name.
 func (e *Engine) Mode() string {
-	return "router-nfqueue"
+	return "router-" + string(e.cfg.Backend)
 }
 
 // Config exposes the current normalized config.

--- a/pkg/router/engine.go
+++ b/pkg/router/engine.go
@@ -1,0 +1,203 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	ErrAlreadyRunning    = errors.New("router engine already running")
+	ErrRouterUnsupported = errors.New("router mode is only supported on Linux")
+)
+
+type lifecycleRunner interface {
+	Start(context.Context) error
+	Stop() error
+}
+
+type runnerFactory func(Config, *logrus.Logger) (lifecycleRunner, error)
+type batchApplier func(context.Context, string) error
+
+// Engine manages the Linux router-mode lifecycle: nftables state plus the
+// NFQUEUE worker that emits fake packets.
+type Engine struct {
+	cfg                Config
+	logger             *logrus.Logger
+	newRunner          runnerFactory
+	applyBatch         batchApplier
+	startupGracePeriod time.Duration
+
+	mu             sync.Mutex
+	runner         lifecycleRunner
+	cancel         context.CancelFunc
+	doneCh         chan error
+	rules          RuleSet
+	rulesInstalled bool
+}
+
+// New constructs a router engine with a default logger.
+func New(cfg Config) *Engine {
+	return NewWithLogger(cfg, nil)
+}
+
+// NewWithLogger constructs a router engine and reuses the provided logger.
+func NewWithLogger(cfg Config, logger *logrus.Logger) *Engine {
+	if logger == nil {
+		logger = logrus.New()
+	}
+	return &Engine{
+		cfg:                cfg.Normalized(),
+		logger:             logger,
+		newRunner:          defaultRunnerFactory,
+		applyBatch:         defaultBatchApplier,
+		startupGracePeriod: 150 * time.Millisecond,
+	}
+}
+
+// Start validates config, installs nftables state, and launches the NFQUEUE worker.
+func (e *Engine) Start(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := e.cfg.Validate(); err != nil {
+		return err
+	}
+
+	rules, err := BuildRuleSet(e.cfg)
+	if err != nil {
+		return err
+	}
+
+	e.mu.Lock()
+	if e.runner != nil {
+		e.mu.Unlock()
+		return ErrAlreadyRunning
+	}
+	newRunner := e.newRunner
+	applyBatch := e.applyBatch
+	logger := e.logger
+	grace := e.startupGracePeriod
+	e.mu.Unlock()
+
+	runner, err := newRunner(e.cfg, logger)
+	if err != nil {
+		return err
+	}
+	if err := applyBatch(ctx, rules.SetupBatch()); err != nil {
+		return fmt.Errorf("install nftables rules: %w", err)
+	}
+
+	childCtx, cancel := context.WithCancel(ctx)
+	doneCh := make(chan error, 1)
+
+	e.mu.Lock()
+	e.runner = runner
+	e.cancel = cancel
+	e.doneCh = doneCh
+	e.rules = rules
+	e.rulesInstalled = true
+	e.mu.Unlock()
+
+	go func() {
+		doneCh <- runner.Start(childCtx)
+	}()
+
+	select {
+	case err := <-doneCh:
+		rollbackErr := e.rollbackStartup(runner, applyBatch, rules)
+		if rollbackErr != nil {
+			if err != nil {
+				return fmt.Errorf("%w; rollback failed: %v", err, rollbackErr)
+			}
+			return rollbackErr
+		}
+		return err
+	case <-time.After(grace):
+		e.logger.WithFields(logrus.Fields{
+			"queue": e.cfg.QueueNum,
+			"wan":   e.cfg.WANInterface,
+			"table": rules.TableName,
+		}).Info("router mode active")
+		return nil
+	}
+}
+
+func (e *Engine) rollbackStartup(runner lifecycleRunner, applyBatch batchApplier, rules RuleSet) error {
+	e.mu.Lock()
+	e.runner = nil
+	e.cancel = nil
+	e.doneCh = nil
+	e.rulesInstalled = false
+	e.mu.Unlock()
+
+	var firstErr error
+	if err := runner.Stop(); err != nil {
+		firstErr = err
+	}
+	if err := applyBatch(context.Background(), rules.TeardownBatch()); err != nil && firstErr == nil {
+		firstErr = fmt.Errorf("remove nftables rules after startup failure: %w", err)
+	}
+	return firstErr
+}
+
+// Stop tears down the worker and removes the nftables table that Start installed.
+func (e *Engine) Stop() error {
+	e.mu.Lock()
+	runner := e.runner
+	cancel := e.cancel
+	doneCh := e.doneCh
+	rules := e.rules
+	rulesInstalled := e.rulesInstalled
+	applyBatch := e.applyBatch
+	e.runner = nil
+	e.cancel = nil
+	e.doneCh = nil
+	e.rulesInstalled = false
+	e.mu.Unlock()
+
+	var firstErr error
+	if cancel != nil {
+		cancel()
+	}
+	if runner != nil {
+		if err := runner.Stop(); err != nil {
+			firstErr = err
+		}
+	}
+	if doneCh != nil {
+		if err := <-doneCh; err != nil && !errors.Is(err, context.Canceled) && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if rulesInstalled {
+		if err := applyBatch(context.Background(), rules.TeardownBatch()); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("remove nftables rules: %w", err)
+		}
+	}
+	return firstErr
+}
+
+// Mode returns the router backend name.
+func (e *Engine) Mode() string {
+	return "router-nfqueue"
+}
+
+// Config exposes the current normalized config.
+func (e *Engine) Config() Config {
+	return e.cfg
+}
+
+// Validate checks whether the current router-mode config is renderable.
+func (e *Engine) Validate() error {
+	return e.cfg.Validate()
+}
+
+// RuleSet returns the current nftables dry-run output for this engine.
+func (e *Engine) RuleSet() (RuleSet, error) {
+	return BuildRuleSet(e.cfg)
+}

--- a/pkg/router/engine_linux.go
+++ b/pkg/router/engine_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package router
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/boratanrikulu/gecit/pkg/router/nfq"
+	"github.com/sirupsen/logrus"
+)
+
+func defaultRunnerFactory(cfg Config, logger *logrus.Logger) (lifecycleRunner, error) {
+	return nfq.NewRunner(cfg, logger)
+}
+
+func defaultBatchApplier(ctx context.Context, batch string) error {
+	if strings.TrimSpace(batch) == "" {
+		return nil
+	}
+
+	cmd := exec.CommandContext(ctx, "nft", "-f", "-")
+	cmd.Stdin = strings.NewReader(batch)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	msg := strings.TrimSpace(string(out))
+	if msg == "" {
+		return fmt.Errorf("nft -f -: %w", err)
+	}
+	return fmt.Errorf("nft -f -: %s: %w", msg, err)
+}

--- a/pkg/router/engine_linux.go
+++ b/pkg/router/engine_linux.go
@@ -8,12 +8,11 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/boratanrikulu/gecit/pkg/router/nfq"
 	"github.com/sirupsen/logrus"
 )
 
 func defaultRunnerFactory(cfg Config, logger *logrus.Logger) (lifecycleRunner, error) {
-	return nfq.NewRunner(cfg, logger)
+	return newNFQRunner(cfg, logger)
 }
 
 func defaultBatchApplier(ctx context.Context, batch string) error {

--- a/pkg/router/engine_other.go
+++ b/pkg/router/engine_other.go
@@ -1,0 +1,17 @@
+//go:build !linux
+
+package router
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+func defaultRunnerFactory(cfg Config, logger *logrus.Logger) (lifecycleRunner, error) {
+	return nil, ErrRouterUnsupported
+}
+
+func defaultBatchApplier(ctx context.Context, batch string) error {
+	return ErrRouterUnsupported
+}

--- a/pkg/router/engine_test.go
+++ b/pkg/router/engine_test.go
@@ -116,3 +116,22 @@ func TestEngineStartRollsBackOnImmediateRunnerFailure(t *testing.T) {
 		t.Fatalf("rollback batch missing delete table: %s", applied[1])
 	}
 }
+
+func TestEngineDryRunBackendStartsWithoutSystemHooks(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.WANInterface = "wan"
+	cfg.Backend = QueueBackendDryRun
+
+	eng := New(cfg)
+	eng.startupGracePeriod = 5 * time.Millisecond
+
+	if got := eng.Mode(); got != "router-dryrun" {
+		t.Fatalf("Mode() = %q, want router-dryrun", got)
+	}
+	if err := eng.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := eng.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+}

--- a/pkg/router/engine_test.go
+++ b/pkg/router/engine_test.go
@@ -1,0 +1,118 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type fakeLifecycleRunner struct {
+	start func(context.Context) error
+	stop  func() error
+}
+
+func (f *fakeLifecycleRunner) Start(ctx context.Context) error {
+	return f.start(ctx)
+}
+
+func (f *fakeLifecycleRunner) Stop() error {
+	if f.stop != nil {
+		return f.stop()
+	}
+	return nil
+}
+
+func TestEngineStartStopAppliesRulesAndRunsWorker(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.WANInterface = "wan"
+
+	eng := New(cfg)
+	eng.startupGracePeriod = 5 * time.Millisecond
+
+	var mu sync.Mutex
+	var applied []string
+	stopped := 0
+	eng.applyBatch = func(ctx context.Context, batch string) error {
+		mu.Lock()
+		applied = append(applied, batch)
+		mu.Unlock()
+		return nil
+	}
+	eng.newRunner = func(cfg Config, _ *logrus.Logger) (lifecycleRunner, error) {
+		return &fakeLifecycleRunner{
+			start: func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+			stop: func() error {
+				stopped++
+				return nil
+			},
+		}, nil
+	}
+
+	if err := eng.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := eng.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(applied) != 2 {
+		t.Fatalf("expected setup+teardown batches, got %d", len(applied))
+	}
+	if !strings.Contains(applied[0], "add table inet gecit_router") {
+		t.Fatalf("setup batch missing add table: %s", applied[0])
+	}
+	if !strings.Contains(applied[1], "delete table inet gecit_router") {
+		t.Fatalf("teardown batch missing delete table: %s", applied[1])
+	}
+	if stopped == 0 {
+		t.Fatal("expected runner.Stop to be called")
+	}
+}
+
+func TestEngineStartRollsBackOnImmediateRunnerFailure(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.WANInterface = "wan"
+
+	eng := New(cfg)
+	eng.startupGracePeriod = 5 * time.Millisecond
+
+	var mu sync.Mutex
+	var applied []string
+	eng.applyBatch = func(ctx context.Context, batch string) error {
+		mu.Lock()
+		applied = append(applied, batch)
+		mu.Unlock()
+		return nil
+	}
+	eng.newRunner = func(cfg Config, _ *logrus.Logger) (lifecycleRunner, error) {
+		return &fakeLifecycleRunner{
+			start: func(ctx context.Context) error {
+				return errors.New("boom")
+			},
+		}, nil
+	}
+
+	err := eng.Start(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected startup failure, got %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(applied) != 2 {
+		t.Fatalf("expected setup+rollback batches, got %d", len(applied))
+	}
+	if !strings.Contains(applied[1], "delete table inet gecit_router") {
+		t.Fatalf("rollback batch missing delete table: %s", applied[1])
+	}
+}

--- a/pkg/router/nfq/runner_linux.go
+++ b/pkg/router/nfq/runner_linux.go
@@ -1,0 +1,146 @@
+//go:build linux
+
+package nfq
+
+import (
+	"context"
+
+	"github.com/boratanrikulu/gecit/pkg/rawsock"
+	"github.com/boratanrikulu/gecit/pkg/router"
+	"github.com/florianl/go-nfqueue/v2"
+	"github.com/sirupsen/logrus"
+)
+
+type socketMarker interface {
+	SetMark(mark uint32) error
+}
+
+// Runner consumes packets from an NFQUEUE and asks a router processor whether to inject.
+type Runner struct {
+	cfg       router.Config
+	processor *router.Processor
+	rawSock   rawsock.RawSocket
+	queue     *nfqueue.Nfqueue
+	logger    *logrus.Logger
+}
+
+// NewRunner creates the experimental Linux NFQUEUE data-plane worker.
+func NewRunner(cfg router.Config, logger *logrus.Logger) (*Runner, error) {
+	processor, err := router.NewProcessor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if logger == nil {
+		logger = logrus.New()
+	}
+
+	return &Runner{
+		cfg:       cfg.Normalized(),
+		processor: processor,
+		logger:    logger,
+	}, nil
+}
+
+// Start opens NFQUEUE and processes packets until the context is canceled.
+func (r *Runner) Start(ctx context.Context) error {
+	if err := r.openRawSocket(); err != nil {
+		return err
+	}
+
+	queue, err := nfqueue.Open(&nfqueue.Config{
+		NfQueue:      r.cfg.QueueNum,
+		MaxQueueLen:  uint32(r.cfg.MaxFlows),
+		MaxPacketLen: 0xffff,
+		Copymode:     nfqueue.NfQnlCopyPacket,
+		Flags:        nfqueue.NfQaCfgFlagFailOpen,
+	})
+	if err != nil {
+		r.rawSock.Close()
+		r.rawSock = nil
+		return err
+	}
+	r.queue = queue
+
+	return r.queue.RegisterWithErrorFunc(ctx, r.handlePacket, r.handleError)
+}
+
+// Stop closes the queue and the raw socket. Both resources are always
+// closed even if one of them returns an error.
+func (r *Runner) Stop() error {
+	var firstErr error
+	if r.queue != nil {
+		if err := r.queue.Close(); err != nil {
+			firstErr = err
+		}
+		r.queue = nil
+	}
+	if r.rawSock != nil {
+		if err := r.rawSock.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		r.rawSock = nil
+	}
+	return firstErr
+}
+
+func (r *Runner) openRawSocket() error {
+	rs, err := rawsock.New()
+	if err != nil {
+		return err
+	}
+	if marker, ok := rs.(socketMarker); ok {
+		if err := marker.SetMark(r.cfg.PacketMark); err != nil {
+			rs.Close()
+			return err
+		}
+	}
+	r.rawSock = rs
+	return nil
+}
+
+func (r *Runner) handlePacket(attr nfqueue.Attribute) int {
+	if attr.PacketID == nil {
+		return 0
+	}
+	if attr.Payload == nil {
+		r.accept(*attr.PacketID)
+		return 0
+	}
+
+	var mark uint32
+	if attr.Mark != nil {
+		mark = *attr.Mark
+	}
+
+	action, err := r.processor.ProcessPacket(*attr.Payload, mark)
+	if err != nil {
+		r.logger.WithError(err).Debug("router processor could not parse queued packet")
+	}
+	if action.Inject {
+		if err := r.rawSock.SendFake(action.Conn, action.FakePayload, r.cfg.FakeTTL); err != nil {
+			r.logger.WithError(err).Warn("router mode fake injection failed")
+		} else {
+			r.logger.WithFields(logrus.Fields{
+				"dst":    action.Conn.DstIP.String(),
+				"port":   action.Conn.DstPort,
+				"reason": action.Reason,
+			}).Debug("router mode injected fake clienthello")
+		}
+	}
+
+	r.accept(*attr.PacketID)
+	return 0
+}
+
+func (r *Runner) handleError(err error) int {
+	if err != nil {
+		r.logger.WithError(err).Warn("nfqueue read error")
+	}
+	return 0
+}
+
+func (r *Runner) accept(id uint32) {
+	if err := r.queue.SetVerdict(id, nfqueue.NfAccept); err != nil {
+		r.logger.WithError(err).Warn("failed to accept queued packet")
+	}
+}

--- a/pkg/router/nftables.go
+++ b/pkg/router/nftables.go
@@ -1,0 +1,127 @@
+package router
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RuleSet is a dry-run representation of the nftables state router mode needs.
+type RuleSet struct {
+	TableName string
+	Setup     []string
+	Teardown  []string
+}
+
+// BuildRuleSet renders the nftables commands required for the planned NFQUEUE path.
+func BuildRuleSet(cfg Config) (RuleSet, error) {
+	cfg = cfg.Normalized()
+	if err := cfg.Validate(); err != nil {
+		return RuleSet{}, err
+	}
+
+	queueChain := "postnat"
+	priority := "srcnat + 1"
+	if !cfg.EnablePostNAT {
+		queueChain = "post"
+		priority = "mangle"
+	}
+
+	setup := []string{
+		fmt.Sprintf("nft add table inet %s", cfg.TableName),
+		fmt.Sprintf(`nft 'add chain inet %s %s { type filter hook postrouting priority %s; }'`, cfg.TableName, queueChain, priority),
+		fmt.Sprintf(
+			`nft add rule inet %s %s oifname %q meta mark and %s == 0 tcp dport %s ct original packets 1-6 queue num %d bypass`,
+			cfg.TableName, queueChain, cfg.WANInterface, formatMark(cfg.PacketMark), formatPortSet(cfg.TCPPorts), cfg.QueueNum,
+		),
+	}
+
+	if cfg.EnableQUIC && len(cfg.UDPPorts) > 0 {
+		setup = append(setup, fmt.Sprintf(
+			`nft add rule inet %s %s oifname %q meta mark and %s == 0 udp dport %s ct original packets 1-6 queue num %d bypass`,
+			cfg.TableName, queueChain, cfg.WANInterface, formatMark(cfg.PacketMark), formatPortSet(cfg.UDPPorts), cfg.QueueNum,
+		))
+	}
+
+	setup = append(setup,
+		fmt.Sprintf(`nft 'add chain inet %s predefrag { type filter hook output priority -401; }'`, cfg.TableName),
+		fmt.Sprintf(`nft add rule inet %s predefrag mark and %s != 0 notrack`, cfg.TableName, formatMark(cfg.PacketMark)),
+	)
+
+	return RuleSet{
+		TableName: cfg.TableName,
+		Setup:     setup,
+		Teardown:  []string{fmt.Sprintf("nft delete table inet %s", cfg.TableName)},
+	}, nil
+}
+
+// ShellScript renders the ruleset as a small reusable shell script.
+func (r RuleSet) ShellScript() string {
+	var b strings.Builder
+	b.WriteString("#!/bin/sh\n")
+	b.WriteString("set -eu\n\n")
+	b.WriteString("# Setup\n")
+	for _, cmd := range r.Setup {
+		b.WriteString(cmd)
+		b.WriteByte('\n')
+	}
+	b.WriteString("\n# Teardown\n")
+	for _, cmd := range r.Teardown {
+		b.WriteString("# ")
+		b.WriteString(cmd)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// SetupBatch renders the setup commands as nft-native statements for `nft -f -`.
+func (r RuleSet) SetupBatch() string {
+	return renderBatch(r.Setup)
+}
+
+// TeardownBatch renders the teardown commands as nft-native statements for `nft -f -`.
+func (r RuleSet) TeardownBatch() string {
+	return renderBatch(r.Teardown)
+}
+
+func renderBatch(commands []string) string {
+	var b strings.Builder
+	for _, cmd := range commands {
+		stmt := nftStatement(cmd)
+		if stmt == "" {
+			continue
+		}
+		b.WriteString(stmt)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func nftStatement(command string) string {
+	command = strings.TrimSpace(command)
+	command = strings.TrimPrefix(command, "nft ")
+	if len(command) >= 2 && command[0] == '\'' && command[len(command)-1] == '\'' {
+		command = command[1 : len(command)-1]
+	}
+	return command
+}
+
+func formatPortSet(ports []uint16) string {
+	if len(ports) == 1 {
+		return fmt.Sprintf("%d", ports[0])
+	}
+
+	var b strings.Builder
+	b.WriteString("{ ")
+	for i, port := range ports {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(fmt.Sprintf("%d", port))
+	}
+	b.WriteString(" }")
+	return b.String()
+}
+
+func formatMark(mark uint32) string {
+	return fmt.Sprintf("0x%08x", mark)
+}

--- a/pkg/router/nftables_test.go
+++ b/pkg/router/nftables_test.go
@@ -1,0 +1,71 @@
+package router
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildRuleSetPostNAT(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.WANInterface = "wan"
+
+	rules, err := BuildRuleSet(cfg)
+	if err != nil {
+		t.Fatalf("BuildRuleSet() error = %v", err)
+	}
+
+	text := strings.Join(rules.Setup, "\n")
+	if !strings.Contains(text, "postnat") {
+		t.Fatalf("setup missing postnat chain: %s", text)
+	}
+	if !strings.Contains(text, `oifname "wan"`) {
+		t.Fatalf("setup missing wan interface: %s", text)
+	}
+	if !strings.Contains(text, "queue num 200") {
+		t.Fatalf("setup missing queue number: %s", text)
+	}
+	if !strings.Contains(text, "notrack") {
+		t.Fatalf("setup missing mark/notrack rule: %s", text)
+	}
+	if strings.Contains(text, "udp dport") {
+		t.Fatalf("udp rule should not render while QUIC is disabled: %s", text)
+	}
+}
+
+func TestBuildRuleSetQUICAndShellScript(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.WANInterface = "pppoe-wan"
+	cfg.EnableQUIC = true
+	cfg.EnablePostNAT = false
+	cfg.TCPPorts = []uint16{80, 443}
+	cfg.UDPPorts = []uint16{443}
+
+	rules, err := BuildRuleSet(cfg)
+	if err != nil {
+		t.Fatalf("BuildRuleSet() error = %v", err)
+	}
+
+	text := strings.Join(rules.Setup, "\n")
+	if !strings.Contains(text, "priority mangle") {
+		t.Fatalf("expected mangle priority when postnat is disabled: %s", text)
+	}
+	if !strings.Contains(text, "udp dport 443") {
+		t.Fatalf("expected udp rule when QUIC is enabled: %s", text)
+	}
+	if !strings.Contains(text, "{ 80, 443 }") {
+		t.Fatalf("expected tcp port set rendering: %s", text)
+	}
+
+	script := rules.ShellScript()
+	if !strings.Contains(script, "#!/bin/sh") || !strings.Contains(script, "# Teardown") {
+		t.Fatalf("unexpected shell script: %s", script)
+	}
+
+	setupBatch := rules.SetupBatch()
+	if strings.Contains(setupBatch, "nft add") {
+		t.Fatalf("setup batch should contain nft-native statements, got: %s", setupBatch)
+	}
+	if !strings.Contains(setupBatch, "add table inet gecit_router") {
+		t.Fatalf("setup batch missing add table statement: %s", setupBatch)
+	}
+}

--- a/pkg/router/packet.go
+++ b/pkg/router/packet.go
@@ -1,0 +1,165 @@
+package router
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// Protocol identifies the L4 protocol of a queued packet.
+type Protocol string
+
+const (
+	ProtocolUnknown Protocol = "unknown"
+	ProtocolTCP     Protocol = "tcp"
+	ProtocolUDP     Protocol = "udp"
+)
+
+// PacketMeta is the normalized view of one queued packet.
+type PacketMeta struct {
+	IPVersion uint8
+	Protocol  Protocol
+	SrcIP     net.IP
+	DstIP     net.IP
+	SrcPort   uint16
+	DstPort   uint16
+	TCP       TCPMeta
+	UDP       UDPMeta
+	Payload   []byte
+}
+
+// TCPMeta contains the fields router mode needs from a TCP packet.
+type TCPMeta struct {
+	Seq uint32
+	Ack uint32
+	SYN bool
+	ACK bool
+	PSH bool
+	RST bool
+	FIN bool
+}
+
+// UDPMeta contains the fields router mode needs from a UDP packet.
+type UDPMeta struct {
+	Length uint16
+}
+
+// ParsePacket extracts a portable metadata view from a raw IPv4 or IPv6 packet.
+func ParsePacket(packet []byte) (PacketMeta, error) {
+	if len(packet) == 0 {
+		return PacketMeta{}, fmt.Errorf("empty packet")
+	}
+
+	switch packet[0] >> 4 {
+	case 4:
+		return parseIPv4(packet)
+	case 6:
+		return parseIPv6(packet)
+	default:
+		return PacketMeta{}, fmt.Errorf("unsupported IP version %d", packet[0]>>4)
+	}
+}
+
+// FlowKey returns a stable key for first-packet gating.
+func (m PacketMeta) FlowKey() string {
+	return fmt.Sprintf("%d|%s|%s|%s|%d|%d", m.IPVersion, m.Protocol, m.SrcIP, m.DstIP, m.SrcPort, m.DstPort)
+}
+
+// LooksLikeTLSClientHello performs a small, conservative check before injection.
+func LooksLikeTLSClientHello(payload []byte) bool {
+	if len(payload) < 9 {
+		return false
+	}
+	if payload[0] != 0x16 {
+		return false
+	}
+	if payload[1] != 0x03 {
+		return false
+	}
+	if payload[5] != 0x01 {
+		return false
+	}
+
+	recordLen := int(binary.BigEndian.Uint16(payload[3:5]))
+	if recordLen < 4 {
+		return false
+	}
+	// Ensure the declared record length doesn't exceed what we actually have.
+	if 5+recordLen > len(payload) {
+		return false
+	}
+
+	handshakeLen := int(payload[6])<<16 | int(payload[7])<<8 | int(payload[8])
+	return handshakeLen > 0
+}
+
+func parseIPv4(packet []byte) (PacketMeta, error) {
+	pkt := gopacket.NewPacket(packet, layers.LayerTypeIPv4, gopacket.DecodeOptions{
+		Lazy:   true,
+		NoCopy: true,
+	})
+	ip4Layer := pkt.Layer(layers.LayerTypeIPv4)
+	if ip4Layer == nil {
+		return PacketMeta{}, fmt.Errorf("missing IPv4 layer")
+	}
+	ip4 := ip4Layer.(*layers.IPv4)
+
+	meta := PacketMeta{
+		IPVersion: 4,
+		SrcIP:     append(net.IP{}, ip4.SrcIP...),
+		DstIP:     append(net.IP{}, ip4.DstIP...),
+	}
+	return fillTransportMetaFromPacket(meta, pkt), nil
+}
+
+func parseIPv6(packet []byte) (PacketMeta, error) {
+	pkt := gopacket.NewPacket(packet, layers.LayerTypeIPv6, gopacket.DecodeOptions{
+		Lazy:   true,
+		NoCopy: true,
+	})
+	ip6Layer := pkt.Layer(layers.LayerTypeIPv6)
+	if ip6Layer == nil {
+		return PacketMeta{}, fmt.Errorf("missing IPv6 layer")
+	}
+	ip6 := ip6Layer.(*layers.IPv6)
+
+	meta := PacketMeta{
+		IPVersion: 6,
+		SrcIP:     append(net.IP{}, ip6.SrcIP...),
+		DstIP:     append(net.IP{}, ip6.DstIP...),
+	}
+	return fillTransportMetaFromPacket(meta, pkt), nil
+}
+
+func fillTransportMetaFromPacket(meta PacketMeta, pkt gopacket.Packet) PacketMeta {
+	if tcpLayer := pkt.Layer(layers.LayerTypeTCP); tcpLayer != nil {
+		tcp := tcpLayer.(*layers.TCP)
+		meta.Protocol = ProtocolTCP
+		meta.SrcPort = uint16(tcp.SrcPort)
+		meta.DstPort = uint16(tcp.DstPort)
+		meta.Payload = append([]byte{}, tcp.Payload...)
+		meta.TCP = TCPMeta{
+			Seq: tcp.Seq,
+			Ack: tcp.Ack,
+			SYN: tcp.SYN,
+			ACK: tcp.ACK,
+			PSH: tcp.PSH,
+			RST: tcp.RST,
+			FIN: tcp.FIN,
+		}
+		return meta
+	}
+	if udpLayer := pkt.Layer(layers.LayerTypeUDP); udpLayer != nil {
+		udp := udpLayer.(*layers.UDP)
+		meta.Protocol = ProtocolUDP
+		meta.SrcPort = uint16(udp.SrcPort)
+		meta.DstPort = uint16(udp.DstPort)
+		meta.Payload = append([]byte{}, udp.Payload...)
+		meta.UDP = UDPMeta{Length: udp.Length}
+		return meta
+	}
+	return meta
+}

--- a/pkg/router/probe/dryrun.go
+++ b/pkg/router/probe/dryrun.go
@@ -1,0 +1,111 @@
+package probe
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/boratanrikulu/gecit/pkg/router"
+)
+
+// DryRun captures the router-mode probe workflow without touching system state.
+type DryRun struct {
+	QueueNum         uint16
+	Targets          []string
+	Candidates       []Candidate
+	SetupCommands    []string
+	TeardownCommands []string
+	Steps            []string
+}
+
+// BuildDryRun combines router nftables planning with probe candidate selection.
+func BuildDryRun(cfg router.Config, plan Plan) (DryRun, error) {
+	cfg = cfg.Normalized()
+	rules, err := router.BuildRuleSet(cfg)
+	if err != nil {
+		return DryRun{}, err
+	}
+
+	plan = normalizePlan(cfg, plan)
+
+	steps := []string{
+		fmt.Sprintf("Install %d nftables setup commands for table %q.", len(rules.Setup), rules.TableName),
+		fmt.Sprintf("Queue the first outbound TCP packets on %s through NFQUEUE %d.", joinPorts(cfg.TCPPorts), cfg.QueueNum),
+		fmt.Sprintf("Probe %d target domains with %d candidate strategy profiles.", len(plan.Targets), len(plan.Candidates)),
+		"Mark generated packets to avoid queue loops and conntrack corruption.",
+	}
+	if cfg.EnableQUIC {
+		steps = append(steps, fmt.Sprintf("Queue outbound UDP packets on %s for QUIC-specific candidate evaluation.", joinPorts(cfg.UDPPorts)))
+	} else {
+		steps = append(steps, "Keep UDP passthrough until a QUIC strategy is explicitly enabled and validated.")
+	}
+
+	return DryRun{
+		QueueNum:         plan.QueueNum,
+		Targets:          append([]string(nil), plan.Targets...),
+		Candidates:       append([]Candidate(nil), plan.Candidates...),
+		SetupCommands:    append([]string(nil), rules.Setup...),
+		TeardownCommands: append([]string(nil), rules.Teardown...),
+		Steps:            steps,
+	}, nil
+}
+
+// Text renders a human-readable dry-run report.
+func (d DryRun) Text() string {
+	var b strings.Builder
+	b.WriteString("Router probe dry run\n")
+	b.WriteString(fmt.Sprintf("Queue: %d\n", d.QueueNum))
+	b.WriteString(fmt.Sprintf("Targets: %s\n", strings.Join(d.Targets, ", ")))
+	b.WriteString("\nCandidates:\n")
+	for _, candidate := range d.Candidates {
+		mode := "tcp"
+		if candidate.UDP && candidate.TCP {
+			mode = "tcp+udp"
+		} else if candidate.UDP {
+			mode = "udp"
+		}
+		b.WriteString(fmt.Sprintf("- %s [%s]\n", candidate.Name, mode))
+	}
+	b.WriteString("\nSetup commands:\n")
+	for _, cmd := range d.SetupCommands {
+		b.WriteString("- ")
+		b.WriteString(cmd)
+		b.WriteByte('\n')
+	}
+	b.WriteString("\nSteps:\n")
+	for _, step := range d.Steps {
+		b.WriteString("- ")
+		b.WriteString(step)
+		b.WriteByte('\n')
+	}
+	b.WriteString("\nTeardown commands:\n")
+	for _, cmd := range d.TeardownCommands {
+		b.WriteString("- ")
+		b.WriteString(cmd)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func normalizePlan(cfg router.Config, plan Plan) Plan {
+	if plan.QueueNum == 0 {
+		plan.QueueNum = cfg.QueueNum
+	}
+	if len(plan.Targets) == 0 {
+		plan.Targets = append([]string(nil), cfg.ProbeTargets...)
+	}
+	if len(plan.Candidates) == 0 {
+		plan.Candidates = append([]Candidate(nil), DefaultPlan().Candidates...)
+	}
+	return plan
+}
+
+func joinPorts(ports []uint16) string {
+	if len(ports) == 0 {
+		return "(none)"
+	}
+	items := make([]string, len(ports))
+	for i, port := range ports {
+		items[i] = fmt.Sprintf("%d", port)
+	}
+	return strings.Join(items, ", ")
+}

--- a/pkg/router/probe/probe.go
+++ b/pkg/router/probe/probe.go
@@ -1,0 +1,42 @@
+package probe
+
+// Candidate describes one strategy the blockcheck-style probe can test.
+type Candidate struct {
+	Name            string
+	TCP             bool
+	UDP             bool
+	RequiresPostNAT bool
+	Notes           string
+}
+
+// Plan describes the minimal state needed to probe router-mode candidates.
+type Plan struct {
+	QueueNum   uint16
+	Targets    []string
+	Candidates []Candidate
+}
+
+// Result captures the outcome of a single candidate against a single target.
+type Result struct {
+	Target    string
+	Candidate string
+	Success   bool
+	Notes     string
+}
+
+// DefaultPlan starts with a single conservative TCP candidate and leaves UDP opt-in.
+func DefaultPlan() Plan {
+	return Plan{
+		QueueNum: 200,
+		Targets:  []string{"discord.com", "youtube.com"},
+		Candidates: []Candidate{
+			{
+				Name:            "tcp-fake-clienthello-low-ttl",
+				TCP:             true,
+				UDP:             false,
+				RequiresPostNAT: true,
+				Notes:           "Baseline TCP desync candidate for router mode.",
+			},
+		},
+	}
+}

--- a/pkg/router/probe/probe_test.go
+++ b/pkg/router/probe/probe_test.go
@@ -1,0 +1,52 @@
+package probe
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/boratanrikulu/gecit/pkg/router"
+)
+
+func TestBuildDryRunUsesConfigDefaults(t *testing.T) {
+	cfg := router.DefaultConfig()
+	cfg.WANInterface = "wan"
+
+	dryRun, err := BuildDryRun(cfg, Plan{})
+	if err != nil {
+		t.Fatalf("BuildDryRun() error = %v", err)
+	}
+
+	if dryRun.QueueNum != 200 {
+		t.Fatalf("QueueNum = %d, want 200", dryRun.QueueNum)
+	}
+	if len(dryRun.Targets) != 2 {
+		t.Fatalf("Targets = %v, want 2 items", dryRun.Targets)
+	}
+	if len(dryRun.Candidates) == 0 {
+		t.Fatal("expected at least one candidate")
+	}
+}
+
+func TestDryRunText(t *testing.T) {
+	cfg := router.DefaultConfig()
+	cfg.WANInterface = "wan"
+	cfg.EnableQUIC = true
+
+	dryRun, err := BuildDryRun(cfg, Plan{
+		Targets: []string{"example.com"},
+	})
+	if err != nil {
+		t.Fatalf("BuildDryRun() error = %v", err)
+	}
+
+	text := dryRun.Text()
+	if !strings.Contains(text, "Router probe dry run") {
+		t.Fatalf("missing title: %s", text)
+	}
+	if !strings.Contains(text, "example.com") {
+		t.Fatalf("missing target: %s", text)
+	}
+	if !strings.Contains(text, "udp") {
+		t.Fatalf("expected UDP mention when QUIC is enabled: %s", text)
+	}
+}

--- a/pkg/router/processor.go
+++ b/pkg/router/processor.go
@@ -1,0 +1,148 @@
+package router
+
+import (
+	"sync"
+	"time"
+
+	"github.com/boratanrikulu/gecit/pkg/fake"
+	"github.com/boratanrikulu/gecit/pkg/rawsock"
+)
+
+const defaultFlowTTL = 2 * time.Minute
+
+// Action describes what router mode should do with a queued packet.
+type Action struct {
+	Inject      bool
+	Conn        rawsock.ConnInfo
+	FakePayload []byte
+	Reason      string
+}
+
+// Processor decides whether a queued packet should trigger a fake injection.
+type Processor struct {
+	cfg         Config
+	flowTTL     time.Duration
+	flows       *flowTable
+	now         func() time.Time
+	fakePayload func() []byte
+}
+
+// NewProcessor returns a stateful router-mode decision engine.
+func NewProcessor(cfg Config) (*Processor, error) {
+	cfg = cfg.Normalized()
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &Processor{
+		cfg:         cfg,
+		flowTTL:     defaultFlowTTL,
+		flows:       newFlowTable(defaultFlowTTL, cfg.MaxFlows),
+		now:         time.Now,
+		fakePayload: fake.RandomTLSClientHello,
+	}, nil
+}
+
+// ProcessPacket classifies one queued packet and decides whether to inject a fake.
+func (p *Processor) ProcessPacket(packet []byte, mark uint32) (Action, error) {
+	if mark&p.cfg.PacketMark != 0 {
+		return Action{Reason: "generated packet mark"}, nil
+	}
+
+	meta, err := ParsePacket(packet)
+	if err != nil {
+		return Action{Reason: "packet parse failed"}, err
+	}
+	if meta.Protocol != ProtocolTCP {
+		return Action{Reason: "non-tcp packet"}, nil
+	}
+	if meta.IPVersion != 4 {
+		return Action{Reason: "ipv6 fake injection not implemented"}, nil
+	}
+	if !portAllowed(meta.DstPort, p.cfg.TCPPorts) {
+		return Action{Reason: "tcp port not targeted"}, nil
+	}
+	if len(meta.Payload) == 0 {
+		return Action{Reason: "tcp packet has no payload"}, nil
+	}
+	if !LooksLikeTLSClientHello(meta.Payload) {
+		return Action{Reason: "tcp payload is not a TLS ClientHello"}, nil
+	}
+
+	if !p.flows.MarkOnce(meta.FlowKey(), p.now()) {
+		return Action{Reason: "flow already handled or flow table full"}, nil
+	}
+
+	conn, ok := packetToConnInfo(meta)
+	if !ok {
+		return Action{Reason: "failed to convert IPs to IPv4"}, nil
+	}
+
+	return Action{
+		Inject:      true,
+		Conn:        conn,
+		FakePayload: p.fakePayload(),
+		Reason:      "inject fake clienthello before queued handshake",
+	}, nil
+}
+
+func packetToConnInfo(meta PacketMeta) (rawsock.ConnInfo, bool) {
+	srcIP4 := meta.SrcIP.To4()
+	dstIP4 := meta.DstIP.To4()
+	if srcIP4 == nil || dstIP4 == nil {
+		return rawsock.ConnInfo{}, false
+	}
+	return rawsock.ConnInfo{
+		SrcIP:   append([]byte{}, srcIP4...),
+		DstIP:   append([]byte{}, dstIP4...),
+		SrcPort: meta.SrcPort,
+		DstPort: meta.DstPort,
+		Seq:     meta.TCP.Seq,
+		Ack:     meta.TCP.Ack,
+	}, true
+}
+
+func portAllowed(port uint16, ports []uint16) bool {
+	for _, candidate := range ports {
+		if candidate == port {
+			return true
+		}
+	}
+	return false
+}
+
+type flowTable struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	limit   int
+	entries map[string]time.Time
+}
+
+func newFlowTable(ttl time.Duration, limit int) *flowTable {
+	return &flowTable{
+		ttl:     ttl,
+		limit:   limit,
+		entries: make(map[string]time.Time),
+	}
+}
+
+func (t *flowTable) MarkOnce(key string, now time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for flowKey, seenAt := range t.entries {
+		if now.Sub(seenAt) > t.ttl {
+			delete(t.entries, flowKey)
+		}
+	}
+
+	if _, exists := t.entries[key]; exists {
+		return false
+	}
+	if len(t.entries) >= t.limit {
+		return false
+	}
+
+	t.entries[key] = now
+	return true
+}

--- a/pkg/router/processor_test.go
+++ b/pkg/router/processor_test.go
@@ -1,0 +1,133 @@
+package router
+
+import (
+	"net"
+	"testing"
+
+	"github.com/boratanrikulu/gecit/pkg/fake"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+func TestParsePacketIPv4TCP(t *testing.T) {
+	packet := buildIPv4TCPPacket(t, fake.TLSClientHello())
+
+	meta, err := ParsePacket(packet)
+	if err != nil {
+		t.Fatalf("ParsePacket() error = %v", err)
+	}
+
+	if meta.Protocol != ProtocolTCP {
+		t.Fatalf("Protocol = %q, want tcp", meta.Protocol)
+	}
+	if meta.IPVersion != 4 {
+		t.Fatalf("IPVersion = %d, want 4", meta.IPVersion)
+	}
+	if meta.SrcPort != 45678 || meta.DstPort != 443 {
+		t.Fatalf("ports = %d -> %d, want 45678 -> 443", meta.SrcPort, meta.DstPort)
+	}
+	if !meta.TCP.PSH || !meta.TCP.ACK {
+		t.Fatalf("expected PSH+ACK flags, got %+v", meta.TCP)
+	}
+}
+
+func TestProcessorInjectsOncePerFlow(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.WANInterface = "wan"
+
+	processor, err := NewProcessor(cfg)
+	if err != nil {
+		t.Fatalf("NewProcessor() error = %v", err)
+	}
+
+	packet := buildIPv4TCPPacket(t, fake.TLSClientHello())
+
+	first, err := processor.ProcessPacket(packet, 0)
+	if err != nil {
+		t.Fatalf("ProcessPacket(first) error = %v", err)
+	}
+	if !first.Inject {
+		t.Fatalf("expected first packet to inject, reason=%q", first.Reason)
+	}
+	if first.Conn.Seq == 0 || len(first.FakePayload) == 0 {
+		t.Fatalf("unexpected action payload: %+v", first)
+	}
+
+	second, err := processor.ProcessPacket(packet, 0)
+	if err != nil {
+		t.Fatalf("ProcessPacket(second) error = %v", err)
+	}
+	if second.Inject {
+		t.Fatalf("expected duplicate flow to be skipped, reason=%q", second.Reason)
+	}
+}
+
+func TestProcessorSkipsMarkedAndNonClientHelloTraffic(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.WANInterface = "wan"
+
+	processor, err := NewProcessor(cfg)
+	if err != nil {
+		t.Fatalf("NewProcessor() error = %v", err)
+	}
+
+	packet := buildIPv4TCPPacket(t, []byte("GET / HTTP/1.1\r\n\r\n"))
+
+	action, err := processor.ProcessPacket(packet, cfg.PacketMark)
+	if err != nil {
+		t.Fatalf("ProcessPacket(marked) error = %v", err)
+	}
+	if action.Inject {
+		t.Fatalf("marked packet should not inject, reason=%q", action.Reason)
+	}
+
+	action, err = processor.ProcessPacket(packet, 0)
+	if err != nil {
+		t.Fatalf("ProcessPacket(http) error = %v", err)
+	}
+	if action.Inject {
+		t.Fatalf("non-clienthello packet should not inject, reason=%q", action.Reason)
+	}
+}
+
+func TestLooksLikeTLSClientHello(t *testing.T) {
+	if !LooksLikeTLSClientHello(fake.TLSClientHello()) {
+		t.Fatal("expected deterministic fake clienthello to match")
+	}
+	if LooksLikeTLSClientHello([]byte("hello")) {
+		t.Fatal("short plaintext must not match")
+	}
+}
+
+func buildIPv4TCPPacket(t *testing.T, payload []byte) []byte {
+	t.Helper()
+
+	ip4 := &layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		SrcIP:    net.IPv4(192, 0, 2, 10),
+		DstIP:    net.IPv4(198, 51, 100, 20),
+		Protocol: layers.IPProtocolTCP,
+	}
+	tcp := &layers.TCP{
+		SrcPort: 45678,
+		DstPort: 443,
+		Seq:     1000,
+		Ack:     2000,
+		PSH:     true,
+		ACK:     true,
+		Window:  64240,
+	}
+	if err := tcp.SetNetworkLayerForChecksum(ip4); err != nil {
+		t.Fatalf("SetNetworkLayerForChecksum() error = %v", err)
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	if err := gopacket.SerializeLayers(buf, gopacket.SerializeOptions{
+		FixLengths:       true,
+		ComputeChecksums: true,
+	}, ip4, tcp, gopacket.Payload(payload)); err != nil {
+		t.Fatalf("SerializeLayers() error = %v", err)
+	}
+	return buf.Bytes()
+}

--- a/pkg/router/runner_linux.go
+++ b/pkg/router/runner_linux.go
@@ -1,12 +1,11 @@
 //go:build linux
 
-package nfq
+package router
 
 import (
 	"context"
 
 	"github.com/boratanrikulu/gecit/pkg/rawsock"
-	"github.com/boratanrikulu/gecit/pkg/router"
 	"github.com/florianl/go-nfqueue/v2"
 	"github.com/sirupsen/logrus"
 )
@@ -15,18 +14,16 @@ type socketMarker interface {
 	SetMark(mark uint32) error
 }
 
-// Runner consumes packets from an NFQUEUE and asks a router processor whether to inject.
-type Runner struct {
-	cfg       router.Config
-	processor *router.Processor
+type nfqRunner struct {
+	cfg       Config
+	processor *Processor
 	rawSock   rawsock.RawSocket
 	queue     *nfqueue.Nfqueue
 	logger    *logrus.Logger
 }
 
-// NewRunner creates the experimental Linux NFQUEUE data-plane worker.
-func NewRunner(cfg router.Config, logger *logrus.Logger) (*Runner, error) {
-	processor, err := router.NewProcessor(cfg)
+func newNFQRunner(cfg Config, logger *logrus.Logger) (*nfqRunner, error) {
+	processor, err := NewProcessor(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -34,15 +31,14 @@ func NewRunner(cfg router.Config, logger *logrus.Logger) (*Runner, error) {
 		logger = logrus.New()
 	}
 
-	return &Runner{
+	return &nfqRunner{
 		cfg:       cfg.Normalized(),
 		processor: processor,
 		logger:    logger,
 	}, nil
 }
 
-// Start opens NFQUEUE and processes packets until the context is canceled.
-func (r *Runner) Start(ctx context.Context) error {
+func (r *nfqRunner) Start(ctx context.Context) error {
 	if err := r.openRawSocket(); err != nil {
 		return err
 	}
@@ -55,7 +51,7 @@ func (r *Runner) Start(ctx context.Context) error {
 		Flags:        nfqueue.NfQaCfgFlagFailOpen,
 	})
 	if err != nil {
-		r.rawSock.Close()
+		_ = r.rawSock.Close()
 		r.rawSock = nil
 		return err
 	}
@@ -64,9 +60,7 @@ func (r *Runner) Start(ctx context.Context) error {
 	return r.queue.RegisterWithErrorFunc(ctx, r.handlePacket, r.handleError)
 }
 
-// Stop closes the queue and the raw socket. Both resources are always
-// closed even if one of them returns an error.
-func (r *Runner) Stop() error {
+func (r *nfqRunner) Stop() error {
 	var firstErr error
 	if r.queue != nil {
 		if err := r.queue.Close(); err != nil {
@@ -83,14 +77,14 @@ func (r *Runner) Stop() error {
 	return firstErr
 }
 
-func (r *Runner) openRawSocket() error {
+func (r *nfqRunner) openRawSocket() error {
 	rs, err := rawsock.New()
 	if err != nil {
 		return err
 	}
 	if marker, ok := rs.(socketMarker); ok {
 		if err := marker.SetMark(r.cfg.PacketMark); err != nil {
-			rs.Close()
+			_ = rs.Close()
 			return err
 		}
 	}
@@ -98,7 +92,7 @@ func (r *Runner) openRawSocket() error {
 	return nil
 }
 
-func (r *Runner) handlePacket(attr nfqueue.Attribute) int {
+func (r *nfqRunner) handlePacket(attr nfqueue.Attribute) int {
 	if attr.PacketID == nil {
 		return 0
 	}
@@ -132,14 +126,14 @@ func (r *Runner) handlePacket(attr nfqueue.Attribute) int {
 	return 0
 }
 
-func (r *Runner) handleError(err error) int {
+func (r *nfqRunner) handleError(err error) int {
 	if err != nil {
 		r.logger.WithError(err).Warn("nfqueue read error")
 	}
 	return 0
 }
 
-func (r *Runner) accept(id uint32) {
+func (r *nfqRunner) accept(id uint32) {
 	if err := r.queue.SetVerdict(id, nfqueue.NfAccept); err != nil {
 		r.logger.WithError(err).Warn("failed to accept queued packet")
 	}

--- a/pkg/tun/handler.go
+++ b/pkg/tun/handler.go
@@ -11,8 +11,8 @@ import (
 
 	gecitdns "github.com/boratanrikulu/gecit/pkg/dns"
 	"github.com/boratanrikulu/gecit/pkg/fake"
-	"github.com/boratanrikulu/gecit/pkg/seqtrack"
 	"github.com/boratanrikulu/gecit/pkg/rawsock"
+	"github.com/boratanrikulu/gecit/pkg/seqtrack"
 	singtun "github.com/sagernet/sing-tun"
 	"github.com/sagernet/sing/common/buf"
 	M "github.com/sagernet/sing/common/metadata"
@@ -94,15 +94,16 @@ func (h *handler) injectAndForward(appConn, serverConn net.Conn, dst string) {
 		Seq: seq, Ack: ack,
 	}
 
+	fakePayload := fake.RandomTLSClientHello()
 	for i := 0; i < 3; i++ {
-		if err := h.mgr.rawSock.SendFake(connInfo, fake.TLSClientHello, h.mgr.cfg.FakeTTL); err != nil {
+		if err := h.mgr.rawSock.SendFake(connInfo, fakePayload, h.mgr.cfg.FakeTTL); err != nil {
 			h.mgr.logger.WithError(err).Warn("SendFake failed")
 			break
 		}
 	}
 	h.mgr.logger.WithFields(logrus.Fields{
 		"dst": dst, "seq": seq, "ack": ack, "ttl": h.mgr.cfg.FakeTTL,
-	}).Info("fake ClientHellos injected")
+	}).Debug("fake ClientHellos injected")
 
 	// Let fakes reach DPI before the real ClientHello.
 	time.Sleep(2 * time.Millisecond)


### PR DESCRIPTION

  - add router runtime lifecycle, nftables/nfqueue engine, and packet processor
  - expose cross-platform dry-run backend for non-Linux planning
  - include Linux router runner build fix

  Validation:
  - go test ./...
  - go test -tags with_gvisor ./...
  