### PR TITLE
Harden Windows TUN runtime and raw capture fallback

### DIFF
--- a/cmd/gecit/app/cleanup_windows.go
+++ b/cmd/gecit/app/cleanup_windows.go
@@ -11,14 +11,12 @@ func platformCleanup() bool {
 	cleaned := false
 
 	// 1. Remove stale TUN routes.
-	// Check if gecit routes exist by looking for 0.0.0.0/1 route to TUN IP.
 	if out, err := exec.Command("route", "print", "0.0.0.0").CombinedOutput(); err == nil {
-		if strings.Contains(string(out), "10.0.85.1") {
+		if commands := staleRouteDeleteCommands(string(out)); len(commands) > 0 {
 			fmt.Println("removing stale routes...")
-			exec.Command("route", "delete", "0.0.0.0", "mask", "128.0.0.0").CombinedOutput()
-			exec.Command("route", "delete", "128.0.0.0", "mask", "128.0.0.0").CombinedOutput()
-			exec.Command("route", "delete", "1.1.1.1").CombinedOutput()
-			exec.Command("route", "delete", "8.8.8.8").CombinedOutput()
+			for _, args := range commands {
+				exec.Command(args[0], args[1:]...).CombinedOutput()
+			}
 			cleaned = true
 		}
 	}
@@ -45,4 +43,18 @@ func platformCleanup() bool {
 	}
 
 	return cleaned
+}
+
+func staleRouteDeleteCommands(routePrint string) [][]string {
+	if !strings.Contains(routePrint, "10.0.85.1") && !strings.Contains(routePrint, "10.0.85.2") {
+		return nil
+	}
+
+	return [][]string{
+		{"route", "delete", "0.0.0.0", "mask", "0.0.0.0", "10.0.85.2"},
+		{"route", "delete", "0.0.0.0", "mask", "128.0.0.0"},
+		{"route", "delete", "128.0.0.0", "mask", "128.0.0.0"},
+		{"route", "delete", "1.1.1.1"},
+		{"route", "delete", "8.8.8.8"},
+	}
 }

--- a/cmd/gecit/app/cleanup_windows_test.go
+++ b/cmd/gecit/app/cleanup_windows_test.go
@@ -1,0 +1,41 @@
+package app
+
+import "testing"
+
+func TestStaleRouteDeleteCommandsForDefaultRoute(t *testing.T) {
+	routePrint := `
+Active Routes:
+Network Destination        Netmask          Gateway       Interface  Metric
+          0.0.0.0          0.0.0.0        10.8.32.1      10.8.46.188     40
+          0.0.0.0          0.0.0.0        10.0.85.2        10.0.85.1      0
+`
+
+	cmds := staleRouteDeleteCommands(routePrint)
+	if len(cmds) == 0 {
+		t.Fatal("staleRouteDeleteCommands returned no commands for stale gecit default route")
+	}
+
+	foundDefaultDelete := false
+	for _, cmd := range cmds {
+		if len(cmd) >= 6 && cmd[0] == "route" && cmd[1] == "delete" && cmd[2] == "0.0.0.0" && cmd[5] == "10.0.85.2" {
+			foundDefaultDelete = true
+			break
+		}
+	}
+	if !foundDefaultDelete {
+		t.Fatal("staleRouteDeleteCommands missing default route delete for 10.0.85.2")
+	}
+}
+
+func TestStaleRouteDeleteCommandsForCleanRoutes(t *testing.T) {
+	routePrint := `
+Active Routes:
+Network Destination        Netmask          Gateway       Interface  Metric
+          0.0.0.0          0.0.0.0        10.8.32.1      10.8.46.188     40
+`
+
+	cmds := staleRouteDeleteCommands(routePrint)
+	if len(cmds) != 0 {
+		t.Fatalf("staleRouteDeleteCommands returned %d commands for clean route table, want 0", len(cmds))
+	}
+}

--- a/cmd/gecit/app/run.go
+++ b/cmd/gecit/app/run.go
@@ -22,6 +22,7 @@ func init() {
 	runCmd.Flags().Int("fake-ttl", 8, "TTL for fake packets (reaches DPI, not server)")
 	runCmd.Flags().Bool("doh", true, "enable built-in DoH DNS resolver")
 	runCmd.Flags().String("doh-upstream", "cloudflare", "DoH upstream: preset (cloudflare,google,quad9,nextdns,adguard) or URL")
+	runCmd.Flags().String("tun-stack", "auto", "darwin/windows TUN stack: auto, system, gvisor, mixed")
 	runCmd.Flags().Int("mss", 40, "TCP MSS for ClientHello fragmentation (Linux only)")
 	runCmd.Flags().Int("restore-after-bytes", 600, "restore normal MSS after N bytes (Linux only)")
 	runCmd.Flags().Int("restore-mss", 0, "restored MSS value, 0 = auto/1460 (Linux only)")
@@ -32,6 +33,7 @@ func init() {
 	viper.BindPFlag("fake_ttl", runCmd.Flags().Lookup("fake-ttl"))
 	viper.BindPFlag("doh_enabled", runCmd.Flags().Lookup("doh"))
 	viper.BindPFlag("doh_upstream", runCmd.Flags().Lookup("doh-upstream"))
+	viper.BindPFlag("tun_stack", runCmd.Flags().Lookup("tun-stack"))
 	viper.BindPFlag("mss", runCmd.Flags().Lookup("mss"))
 	viper.BindPFlag("restore_after_bytes", runCmd.Flags().Lookup("restore-after-bytes"))
 	viper.BindPFlag("restore_mss", runCmd.Flags().Lookup("restore-mss"))
@@ -57,6 +59,7 @@ func runEngine(cmd *cobra.Command, args []string) error {
 		RestoreAfterBytes: viper.GetInt("restore_after_bytes"),
 		Ports:             toUint16Slice(viper.GetIntSlice("ports")),
 		Interface:         viper.GetString("interface"),
+		TunStack:          viper.GetString("tun_stack"),
 		CgroupPath:        viper.GetString("cgroup_path"),
 		FakeTTL:           viper.GetInt("fake_ttl"),
 		DoHEnabled:        viper.GetBool("doh_enabled"),

--- a/cmd/gecit/app/run_tun.go
+++ b/cmd/gecit/app/run_tun.go
@@ -28,6 +28,7 @@ func newPlatformEngine(cfg engine.Config, logger *logrus.Logger) (engine.Engine,
 		Ports:     cfg.Ports,
 		FakeTTL:   cfg.FakeTTL,
 		Interface: cfg.Interface,
+		Stack:     cfg.TunStack,
 	}, logger)
 
 	return &tunEngine{
@@ -76,4 +77,4 @@ func (e *tunEngine) Stop() error {
 	return nil
 }
 
-func (e *tunEngine) Mode() string { return "tun" }
+func (e *tunEngine) Mode() string { return "tun-" + e.mgr.StackName() }

--- a/cmd/gecit/app/status_darwin.go
+++ b/cmd/gecit/app/status_darwin.go
@@ -3,10 +3,17 @@ package app
 import (
 	"fmt"
 	"os"
+
+	singtun "github.com/sagernet/sing-tun"
 )
 
 func printPlatformStatus() {
 	fmt.Printf("  engine:     tun\n")
+	if singtun.WithGVisor {
+		fmt.Printf("  tun stack:  gvisor (default), system/mixed available\n")
+	} else {
+		fmt.Printf("  tun stack:  system (default), gvisor not built in\n")
+	}
 
 	if os.Geteuid() != 0 {
 		fmt.Printf("  (run with sudo for accurate capability detection)\n")

--- a/cmd/gecit/app/status_windows.go
+++ b/cmd/gecit/app/status_windows.go
@@ -1,9 +1,18 @@
 package app
 
-import "fmt"
+import (
+	"fmt"
+
+	singtun "github.com/sagernet/sing-tun"
+)
 
 func printPlatformStatus() {
 	fmt.Printf("  engine:     tun (wintun)\n")
+	if singtun.WithGVisor {
+		fmt.Printf("  tun stack:  gvisor (default), system/mixed available\n")
+	} else {
+		fmt.Printf("  tun stack:  system (default), gvisor not built in\n")
+	}
 
 	if err := checkPrivileges(); err != nil {
 		fmt.Printf("  (run as Administrator for accurate capability detection)\n")
@@ -11,4 +20,5 @@ func printPlatformStatus() {
 	}
 
 	fmt.Printf("  wintun:     available\n")
+	fmt.Printf("  injection:  available\n")
 }

--- a/pkg/capture/capture_windows.go
+++ b/pkg/capture/capture_windows.go
@@ -2,8 +2,168 @@
 
 package capture
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"unsafe"
 
-func NewCapture(_ string, _ []uint16) (Detector, error) {
-	return nil, fmt.Errorf("Npcap support requires CGO build — rebuild with CGO_ENABLED=1 and Npcap installed")
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	sioRcvAll = windows.IOC_IN | windows.IOC_VENDOR | 1
+	rcvAllOn  = 1
+)
+
+type rawCapture struct {
+	socket    windows.Handle
+	ports     map[uint16]bool
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func NewCapture(iface string, ports []uint16) (Detector, error) {
+	localIP, err := resolveInterfaceIPv4(iface)
+	if err != nil {
+		return nil, err
+	}
+
+	socket, err := windows.Socket(windows.AF_INET, windows.SOCK_RAW, windows.IPPROTO_IP)
+	if err != nil {
+		return nil, fmt.Errorf("raw capture socket: %w", err)
+	}
+
+	if err := windows.Bind(socket, &windows.SockaddrInet4{Addr: localIP}); err != nil {
+		windows.Closesocket(socket)
+		return nil, fmt.Errorf("bind raw capture socket: %w", err)
+	}
+	if err := windows.SetsockoptInt(socket, windows.SOL_SOCKET, windows.SO_RCVTIMEO, 250); err != nil {
+		windows.Closesocket(socket)
+		return nil, fmt.Errorf("set raw capture timeout: %w", err)
+	}
+
+	mode := uint32(rcvAllOn)
+	var bytesReturned uint32
+	if err := windows.WSAIoctl(
+		socket,
+		sioRcvAll,
+		(*byte)(unsafe.Pointer(&mode)),
+		uint32(unsafe.Sizeof(mode)),
+		nil,
+		0,
+		&bytesReturned,
+		nil,
+		0,
+	); err != nil {
+		windows.Closesocket(socket)
+		return nil, fmt.Errorf("enable raw capture on %s: %w", iface, err)
+	}
+
+	portMap := make(map[uint16]bool, len(ports))
+	for _, port := range ports {
+		portMap[port] = true
+	}
+
+	return &rawCapture{
+		socket: socket,
+		ports:  portMap,
+		done:   make(chan struct{}),
+	}, nil
+}
+
+func (c *rawCapture) Start(cb Callback) error {
+	go c.loop(cb)
+	return nil
+}
+
+func (c *rawCapture) Stop() error {
+	c.closeOnce.Do(func() {
+		close(c.done)
+		_ = windows.Closesocket(c.socket)
+	})
+	return nil
+}
+
+func (c *rawCapture) loop(cb Callback) {
+	buf := make([]byte, 65535)
+	for {
+		n, _, err := windows.Recvfrom(c.socket, buf, 0)
+		if err != nil {
+			select {
+			case <-c.done:
+				return
+			default:
+			}
+			if errors.Is(err, windows.WSAETIMEDOUT) {
+				continue
+			}
+			return
+		}
+		if n == 0 {
+			continue
+		}
+		c.processPacket(buf[:n], cb)
+	}
+}
+
+func (c *rawCapture) processPacket(packet []byte, cb Callback) {
+	pkt := gopacket.NewPacket(packet, layers.LayerTypeIPv4, gopacket.DecodeOptions{
+		Lazy:   true,
+		NoCopy: true,
+	})
+	ipLayer := pkt.Layer(layers.LayerTypeIPv4)
+	if ipLayer == nil {
+		return
+	}
+	tcpLayer := pkt.Layer(layers.LayerTypeTCP)
+	if tcpLayer == nil {
+		return
+	}
+
+	ip4 := ipLayer.(*layers.IPv4)
+	tcp := tcpLayer.(*layers.TCP)
+	if !tcp.SYN || !tcp.ACK {
+		return
+	}
+	if !c.ports[uint16(tcp.SrcPort)] {
+		return
+	}
+
+	cb(ConnectionEvent{
+		SrcIP:   append(net.IP{}, ip4.DstIP.To4()...),
+		DstIP:   append(net.IP{}, ip4.SrcIP.To4()...),
+		SrcPort: uint16(tcp.DstPort),
+		DstPort: uint16(tcp.SrcPort),
+		Seq:     tcp.Ack,
+		Ack:     tcp.Seq + 1,
+	})
+}
+
+func resolveInterfaceIPv4(name string) ([4]byte, error) {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return [4]byte{}, fmt.Errorf("interface %s: %w", name, err)
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return [4]byte{}, fmt.Errorf("addresses for %s: %w", name, err)
+	}
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		ip4 := ipNet.IP.To4()
+		if ip4 == nil || ip4.IsLoopback() {
+			continue
+		}
+		var out [4]byte
+		copy(out[:], ip4)
+		return out, nil
+	}
+	return [4]byte{}, fmt.Errorf("no IPv4 address found on %s", name)
 }

--- a/pkg/capture/capture_windows.go
+++ b/pkg/capture/capture_windows.go
@@ -20,47 +20,19 @@ const (
 )
 
 type rawCapture struct {
-	socket    windows.Handle
+	socket4   windows.Handle
+	socket6   windows.Handle
+	hasIPv4   bool
+	hasIPv6   bool
 	ports     map[uint16]bool
 	done      chan struct{}
 	closeOnce sync.Once
 }
 
 func NewCapture(iface string, ports []uint16) (Detector, error) {
-	localIP, err := resolveInterfaceIPv4(iface)
+	localIPv4, localIPv6, err := resolveInterfaceIPs(iface)
 	if err != nil {
 		return nil, err
-	}
-
-	socket, err := windows.Socket(windows.AF_INET, windows.SOCK_RAW, windows.IPPROTO_IP)
-	if err != nil {
-		return nil, fmt.Errorf("raw capture socket: %w", err)
-	}
-
-	if err := windows.Bind(socket, &windows.SockaddrInet4{Addr: localIP}); err != nil {
-		windows.Closesocket(socket)
-		return nil, fmt.Errorf("bind raw capture socket: %w", err)
-	}
-	if err := windows.SetsockoptInt(socket, windows.SOL_SOCKET, windows.SO_RCVTIMEO, 250); err != nil {
-		windows.Closesocket(socket)
-		return nil, fmt.Errorf("set raw capture timeout: %w", err)
-	}
-
-	mode := uint32(rcvAllOn)
-	var bytesReturned uint32
-	if err := windows.WSAIoctl(
-		socket,
-		sioRcvAll,
-		(*byte)(unsafe.Pointer(&mode)),
-		uint32(unsafe.Sizeof(mode)),
-		nil,
-		0,
-		&bytesReturned,
-		nil,
-		0,
-	); err != nil {
-		windows.Closesocket(socket)
-		return nil, fmt.Errorf("enable raw capture on %s: %w", iface, err)
 	}
 
 	portMap := make(map[uint16]bool, len(ports))
@@ -68,30 +40,64 @@ func NewCapture(iface string, ports []uint16) (Detector, error) {
 		portMap[port] = true
 	}
 
-	return &rawCapture{
-		socket: socket,
-		ports:  portMap,
-		done:   make(chan struct{}),
-	}, nil
+	capture := &rawCapture{
+		ports: portMap,
+		done:  make(chan struct{}),
+	}
+
+	if localIPv4 != nil {
+		socket, err := openRawCaptureSocket4(localIPv4)
+		if err != nil {
+			return nil, err
+		}
+		capture.socket4 = socket
+		capture.hasIPv4 = true
+	}
+	if localIPv6 != nil {
+		socket, err := openRawCaptureSocket6(localIPv6)
+		if err != nil {
+			if capture.hasIPv4 {
+				_ = windows.Closesocket(capture.socket4)
+			}
+			return nil, err
+		}
+		capture.socket6 = socket
+		capture.hasIPv6 = true
+	}
+	if !capture.hasIPv4 && !capture.hasIPv6 {
+		return nil, fmt.Errorf("no usable IPv4 or IPv6 address found on %s", iface)
+	}
+
+	return capture, nil
 }
 
 func (c *rawCapture) Start(cb Callback) error {
-	go c.loop(cb)
+	if c.hasIPv4 {
+		go c.loop(c.socket4, cb)
+	}
+	if c.hasIPv6 {
+		go c.loop(c.socket6, cb)
+	}
 	return nil
 }
 
 func (c *rawCapture) Stop() error {
 	c.closeOnce.Do(func() {
 		close(c.done)
-		_ = windows.Closesocket(c.socket)
+		if c.hasIPv4 {
+			_ = windows.Closesocket(c.socket4)
+		}
+		if c.hasIPv6 {
+			_ = windows.Closesocket(c.socket6)
+		}
 	})
 	return nil
 }
 
-func (c *rawCapture) loop(cb Callback) {
+func (c *rawCapture) loop(socket windows.Handle, cb Callback) {
 	buf := make([]byte, 65535)
 	for {
-		n, _, err := windows.Recvfrom(c.socket, buf, 0)
+		n, _, err := windows.Recvfrom(socket, buf, 0)
 		if err != nil {
 			select {
 			case <-c.done:
@@ -111,16 +117,26 @@ func (c *rawCapture) loop(cb Callback) {
 }
 
 func (c *rawCapture) processPacket(packet []byte, cb Callback) {
+	if len(packet) == 0 {
+		return
+	}
+
+	switch packet[0] >> 4 {
+	case 4:
+		c.processIPv4(packet, cb)
+	case 6:
+		c.processIPv6(packet, cb)
+	}
+}
+
+func (c *rawCapture) processIPv4(packet []byte, cb Callback) {
 	pkt := gopacket.NewPacket(packet, layers.LayerTypeIPv4, gopacket.DecodeOptions{
 		Lazy:   true,
 		NoCopy: true,
 	})
 	ipLayer := pkt.Layer(layers.LayerTypeIPv4)
-	if ipLayer == nil {
-		return
-	}
 	tcpLayer := pkt.Layer(layers.LayerTypeTCP)
-	if tcpLayer == nil {
+	if ipLayer == nil || tcpLayer == nil {
 		return
 	}
 
@@ -143,27 +159,127 @@ func (c *rawCapture) processPacket(packet []byte, cb Callback) {
 	})
 }
 
-func resolveInterfaceIPv4(name string) ([4]byte, error) {
+func (c *rawCapture) processIPv6(packet []byte, cb Callback) {
+	pkt := gopacket.NewPacket(packet, layers.LayerTypeIPv6, gopacket.DecodeOptions{
+		Lazy:   true,
+		NoCopy: true,
+	})
+	ipLayer := pkt.Layer(layers.LayerTypeIPv6)
+	tcpLayer := pkt.Layer(layers.LayerTypeTCP)
+	if ipLayer == nil || tcpLayer == nil {
+		return
+	}
+
+	ip6 := ipLayer.(*layers.IPv6)
+	tcp := tcpLayer.(*layers.TCP)
+	if !tcp.SYN || !tcp.ACK {
+		return
+	}
+	if !c.ports[uint16(tcp.SrcPort)] {
+		return
+	}
+
+	cb(ConnectionEvent{
+		SrcIP:   append(net.IP{}, ip6.DstIP.To16()...),
+		DstIP:   append(net.IP{}, ip6.SrcIP.To16()...),
+		SrcPort: uint16(tcp.DstPort),
+		DstPort: uint16(tcp.SrcPort),
+		Seq:     tcp.Ack,
+		Ack:     tcp.Seq + 1,
+	})
+}
+
+func resolveInterfaceIPs(name string) (net.IP, net.IP, error) {
 	iface, err := net.InterfaceByName(name)
 	if err != nil {
-		return [4]byte{}, fmt.Errorf("interface %s: %w", name, err)
+		return nil, nil, fmt.Errorf("interface %s: %w", name, err)
 	}
 	addrs, err := iface.Addrs()
 	if err != nil {
-		return [4]byte{}, fmt.Errorf("addresses for %s: %w", name, err)
+		return nil, nil, fmt.Errorf("addresses for %s: %w", name, err)
 	}
+
+	var ipv4 net.IP
+	var ipv6 net.IP
 	for _, addr := range addrs {
 		ipNet, ok := addr.(*net.IPNet)
 		if !ok {
 			continue
 		}
 		ip4 := ipNet.IP.To4()
-		if ip4 == nil || ip4.IsLoopback() {
+		if ip4 != nil && !ip4.IsLoopback() && ipv4 == nil {
+			ipv4 = append(net.IP{}, ip4...)
 			continue
 		}
-		var out [4]byte
-		copy(out[:], ip4)
-		return out, nil
+		ip16 := ipNet.IP.To16()
+		if ip16 != nil && !ipNet.IP.IsLoopback() && ip4 == nil && ipv6 == nil {
+			ipv6 = append(net.IP{}, ip16...)
+		}
 	}
-	return [4]byte{}, fmt.Errorf("no IPv4 address found on %s", name)
+	if ipv4 == nil && ipv6 == nil {
+		return nil, nil, fmt.Errorf("no IPv4 or IPv6 address found on %s", name)
+	}
+	return ipv4, ipv6, nil
+}
+
+func openRawCaptureSocket4(localIP net.IP) (windows.Handle, error) {
+	socket, err := windows.Socket(windows.AF_INET, windows.SOCK_RAW, windows.IPPROTO_IP)
+	if err != nil {
+		return 0, fmt.Errorf("raw ipv4 capture socket: %w", err)
+	}
+
+	addr := &windows.SockaddrInet4{}
+	copy(addr.Addr[:], localIP.To4())
+	if err := windows.Bind(socket, addr); err != nil {
+		windows.Closesocket(socket)
+		return 0, fmt.Errorf("bind raw ipv4 capture socket: %w", err)
+	}
+	if err := windows.SetsockoptInt(socket, windows.SOL_SOCKET, windows.SO_RCVTIMEO, 250); err != nil {
+		windows.Closesocket(socket)
+		return 0, fmt.Errorf("set raw ipv4 capture timeout: %w", err)
+	}
+	if err := enableRawCapture(socket); err != nil {
+		windows.Closesocket(socket)
+		return 0, fmt.Errorf("enable raw ipv4 capture: %w", err)
+	}
+	return socket, nil
+}
+
+func openRawCaptureSocket6(localIP net.IP) (windows.Handle, error) {
+	socket, err := windows.Socket(windows.AF_INET6, windows.SOCK_RAW, windows.IPPROTO_IPV6)
+	if err != nil {
+		return 0, fmt.Errorf("raw ipv6 capture socket: %w", err)
+	}
+
+	addr := &windows.SockaddrInet6{}
+	copy(addr.Addr[:], localIP.To16())
+	if err := windows.Bind(socket, addr); err != nil {
+		windows.Closesocket(socket)
+		return 0, fmt.Errorf("bind raw ipv6 capture socket: %w", err)
+	}
+	if err := windows.SetsockoptInt(socket, windows.SOL_SOCKET, windows.SO_RCVTIMEO, 250); err != nil {
+		windows.Closesocket(socket)
+		return 0, fmt.Errorf("set raw ipv6 capture timeout: %w", err)
+	}
+	if err := enableRawCapture(socket); err != nil {
+		windows.Closesocket(socket)
+		return 0, fmt.Errorf("enable raw ipv6 capture: %w", err)
+	}
+	return socket, nil
+}
+
+func enableRawCapture(socket windows.Handle) error {
+	mode := uint32(rcvAllOn)
+	var bytesReturned uint32
+	return windows.WSAIoctl(
+		socket,
+		sioRcvAll,
+		(*byte)(unsafe.Pointer(&mode)),
+		uint32(unsafe.Sizeof(mode)),
+		nil,
+		0,
+		&bytesReturned,
+		nil,
+		0,
+	)
 }

--- a/pkg/capture/capture_windows.go
+++ b/pkg/capture/capture_windows.go
@@ -1,4 +1,4 @@
-//go:build windows && !cgo
+//go:build windows
 
 package capture
 
@@ -30,6 +30,20 @@ type rawCapture struct {
 }
 
 func NewCapture(iface string, ports []uint16) (Detector, error) {
+	if det, err, ok := tryPcapCapture(iface, ports); ok {
+		if err == nil {
+			return det, nil
+		}
+		rawDet, rawErr := newRawCapture(iface, ports)
+		if rawErr == nil {
+			return rawDet, nil
+		}
+		return nil, fmt.Errorf("pcap capture failed: %v; raw capture failed: %w", err, rawErr)
+	}
+	return newRawCapture(iface, ports)
+}
+
+func newRawCapture(iface string, ports []uint16) (Detector, error) {
 	localIPv4, localIPv6, err := resolveInterfaceIPs(iface)
 	if err != nil {
 		return nil, err

--- a/pkg/capture/capture_windows_pcap.go
+++ b/pkg/capture/capture_windows_pcap.go
@@ -19,26 +19,26 @@ type pcapCapture struct {
 	done   chan struct{}
 }
 
-func NewCapture(iface string, ports []uint16) (Detector, error) {
+func tryPcapCapture(iface string, ports []uint16) (Detector, error, bool) {
 	if !NpcapAvailable() {
-		return nil, fmt.Errorf("Npcap not installed — required for DPI bypass on Windows (download from npcap.com)")
+		return nil, fmt.Errorf("Npcap not installed — required for pcap capture on Windows (download from npcap.com)"), true
 	}
 
 	// Windows pcap needs device path (\Device\NPF_{GUID}), not friendly name.
 	pcapDev, err := resolvePcapDevice(iface)
 	if err != nil {
-		return nil, err
+		return nil, err, true
 	}
 
 	handle, err := pcap.OpenLive(pcapDev, 68, false, 100*time.Millisecond)
 	if err != nil {
-		return nil, fmt.Errorf("pcap open %s: %w", iface, err)
+		return nil, fmt.Errorf("pcap open %s: %w", iface, err), true
 	}
 
 	filter := "tcp src port 443 and tcp[tcpflags] & (tcp-syn|tcp-ack) = (tcp-syn|tcp-ack)"
 	if err := handle.SetBPFFilter(filter); err != nil {
 		handle.Close()
-		return nil, fmt.Errorf("set BPF filter: %w", err)
+		return nil, fmt.Errorf("set BPF filter: %w", err), true
 	}
 
 	portMap := make(map[uint16]bool)
@@ -50,7 +50,7 @@ func NewCapture(iface string, ports []uint16) (Detector, error) {
 		handle: handle,
 		ports:  portMap,
 		done:   make(chan struct{}),
-	}, nil
+	}, nil, true
 }
 
 func (c *pcapCapture) Start(cb Callback) error {

--- a/pkg/capture/capture_windows_pcap_stub.go
+++ b/pkg/capture/capture_windows_pcap_stub.go
@@ -1,0 +1,7 @@
+//go:build windows && !cgo
+
+package capture
+
+func tryPcapCapture(iface string, ports []uint16) (Detector, error, bool) {
+	return nil, nil, false
+}

--- a/pkg/engine/config.go
+++ b/pkg/engine/config.go
@@ -6,6 +6,7 @@ type Config struct {
 	RestoreAfterBytes int      `yaml:"restore_after_bytes" mapstructure:"restore_after_bytes"`
 	Ports             []uint16 `yaml:"ports" mapstructure:"ports"`
 	Interface         string   `yaml:"interface" mapstructure:"interface"`
+	TunStack          string   `yaml:"tun_stack" mapstructure:"tun_stack"`
 	CgroupPath        string   `yaml:"cgroup_path" mapstructure:"cgroup_path"`
 	FakeTTL           int      `yaml:"fake_ttl" mapstructure:"fake_ttl"`
 	DoHEnabled        bool     `yaml:"doh_enabled" mapstructure:"doh_enabled"`
@@ -18,6 +19,7 @@ func DefaultConfig() Config {
 		RestoreMSS:        0,
 		RestoreAfterBytes: 600,
 		Ports:             []uint16{443},
+		TunStack:          "auto",
 		CgroupPath:        "/sys/fs/cgroup",
 		FakeTTL:           8,
 		DoHEnabled:        true,

--- a/pkg/engine/config_test.go
+++ b/pkg/engine/config_test.go
@@ -16,6 +16,7 @@ func TestDefaultConfig(t *testing.T) {
 		{"FakeTTL", cfg.FakeTTL, 8},
 		{"DoHEnabled", cfg.DoHEnabled, true},
 		{"DoHUpstream", cfg.DoHUpstream, "cloudflare"},
+		{"TunStack", cfg.TunStack, "auto"},
 		{"CgroupPath", cfg.CgroupPath, "/sys/fs/cgroup"},
 	}
 

--- a/pkg/rawsock/mark_linux.go
+++ b/pkg/rawsock/mark_linux.go
@@ -1,0 +1,23 @@
+//go:build linux
+
+package rawsock
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// SetMark marks all packets emitted from this raw socket.
+func (s *platformRawSocket) SetMark(mark uint32) error {
+	if err := syscall.SetsockoptInt(s.fd4, syscall.SOL_SOCKET, syscall.SO_MARK, int(mark)); err != nil {
+		return fmt.Errorf("SO_MARK: %w", err)
+	}
+	s.packetMark = mark
+	s.hasMark = true
+	if s.fd6 >= 0 {
+		if err := syscall.SetsockoptInt(s.fd6, syscall.SOL_SOCKET, syscall.SO_MARK, int(mark)); err != nil {
+			return fmt.Errorf("SO_MARK: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/rawsock/rawsock.go
+++ b/pkg/rawsock/rawsock.go
@@ -16,6 +16,12 @@ type ConnInfo struct {
 	Ack     uint32 // TCP ACK number (rcv_nxt from the connection)
 }
 
+const (
+	ipFamilyUnknown = 0
+	ipFamilyIPv4    = 4
+	ipFamilyIPv6    = 6
+)
+
 // RawSocket sends crafted TCP packets with custom TTL.
 type RawSocket interface {
 	// SendFake sends a fake TCP data packet that DPI will process
@@ -27,8 +33,35 @@ type RawSocket interface {
 // BuildPacket constructs a complete IP+TCP packet with the given payload.
 // Used by both Linux and macOS raw socket implementations.
 func BuildPacket(conn ConnInfo, payload []byte, ttl int) []byte {
+	switch connIPFamily(conn) {
+	case ipFamilyIPv4:
+		return buildIPv4Packet(conn, payload, ttl)
+	case ipFamilyIPv6:
+		return buildIPv6Packet(conn, payload, ttl)
+	default:
+		return nil
+	}
+}
+
+func connIPFamily(conn ConnInfo) int {
+	src4 := conn.SrcIP.To4()
+	dst4 := conn.DstIP.To4()
+	switch {
+	case src4 != nil && dst4 != nil:
+		return ipFamilyIPv4
+	case conn.SrcIP.To16() != nil && conn.DstIP.To16() != nil:
+		return ipFamilyIPv6
+	default:
+		return ipFamilyUnknown
+	}
+}
+
+func buildIPv4Packet(conn ConnInfo, payload []byte, ttl int) []byte {
 	tcpHdr := buildTCPHeader(conn)
 	ipHdr := buildIPHeader(conn, ttl, len(tcpHdr)+len(payload))
+	if len(ipHdr) == 0 {
+		return nil
+	}
 
 	pkt := make([]byte, 0, len(ipHdr)+len(tcpHdr)+len(payload))
 	pkt = append(pkt, ipHdr...)
@@ -52,7 +85,44 @@ func BuildPacket(conn ConnInfo, payload []byte, ttl int) []byte {
 	return pkt
 }
 
+func buildIPv6Packet(conn ConnInfo, payload []byte, ttl int) []byte {
+	srcIP := conn.SrcIP.To16()
+	dstIP := conn.DstIP.To16()
+	if srcIP == nil || dstIP == nil {
+		return nil
+	}
+
+	tcpHdr := buildTCPHeader(conn)
+	ipHdr := buildIPv6Header(srcIP, dstIP, ttl, len(tcpHdr)+len(payload))
+
+	pkt := make([]byte, 0, len(ipHdr)+len(tcpHdr)+len(payload))
+	pkt = append(pkt, ipHdr...)
+	pkt = append(pkt, tcpHdr...)
+	pkt = append(pkt, payload...)
+
+	tcpChecksumOffset := len(ipHdr) + 16
+	checksumData := make([]byte, 0, 40+len(tcpHdr)+len(payload))
+	checksumData = append(checksumData, srcIP...)
+	checksumData = append(checksumData, dstIP...)
+	tcpLenBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(tcpLenBuf, uint32(len(tcpHdr)+len(payload)))
+	checksumData = append(checksumData, tcpLenBuf...)
+	checksumData = append(checksumData, 0, 0, 0, syscall.IPPROTO_TCP)
+	checksumData = append(checksumData, pkt[len(ipHdr):]...)
+	cs := Checksum(checksumData)
+	pkt[tcpChecksumOffset] = byte(cs >> 8)
+	pkt[tcpChecksumOffset+1] = byte(cs)
+
+	return pkt
+}
+
 func buildIPHeader(conn ConnInfo, ttl int, payloadLen int) []byte {
+	srcIP := conn.SrcIP.To4()
+	dstIP := conn.DstIP.To4()
+	if srcIP == nil || dstIP == nil {
+		return nil
+	}
+
 	totalLen := 20 + payloadLen
 	hdr := make([]byte, 20)
 	hdr[0] = 0x45                                 // Version=4, IHL=5
@@ -60,12 +130,23 @@ func buildIPHeader(conn ConnInfo, ttl int, payloadLen int) []byte {
 	ipHeaderPutUint16(hdr[4:6], 0x1234)           // ID
 	hdr[8] = byte(ttl)                            // TTL
 	hdr[9] = syscall.IPPROTO_TCP                  // Protocol
-	copy(hdr[12:16], conn.SrcIP.To4())
-	copy(hdr[16:20], conn.DstIP.To4())
+	copy(hdr[12:16], srcIP)
+	copy(hdr[16:20], dstIP)
 	// IP header checksum — required for pcap_sendpacket (kernel won't fill it).
 	cs := Checksum(hdr)
 	hdr[10] = byte(cs >> 8)
 	hdr[11] = byte(cs)
+	return hdr
+}
+
+func buildIPv6Header(srcIP, dstIP net.IP, ttl int, payloadLen int) []byte {
+	hdr := make([]byte, 40)
+	hdr[0] = 0x60 // Version 6, traffic class and flow label are zeroed.
+	binary.BigEndian.PutUint16(hdr[4:6], uint16(payloadLen))
+	hdr[6] = syscall.IPPROTO_TCP
+	hdr[7] = byte(ttl)
+	copy(hdr[8:24], srcIP)
+	copy(hdr[24:40], dstIP)
 	return hdr
 }
 

--- a/pkg/rawsock/rawsock_darwin.go
+++ b/pkg/rawsock/rawsock_darwin.go
@@ -24,7 +24,14 @@ func New() (RawSocket, error) {
 }
 
 func (s *platformRawSocket) SendFake(conn ConnInfo, payload []byte, ttl int) error {
+	if connIPFamily(conn) != ipFamilyIPv4 {
+		return fmt.Errorf("raw IPv6 injection is not supported on darwin")
+	}
+
 	pkt := BuildPacket(conn, payload, ttl)
+	if len(pkt) == 0 {
+		return fmt.Errorf("invalid IP family or address pair")
+	}
 
 	addr := syscall.SockaddrInet4{Port: 0}
 	copy(addr.Addr[:], conn.DstIP.To4())

--- a/pkg/rawsock/rawsock_linux.go
+++ b/pkg/rawsock/rawsock_linux.go
@@ -3,10 +3,15 @@ package rawsock
 import (
 	"fmt"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 type platformRawSocket struct {
-	fd int
+	fd4        int
+	fd6        int
+	packetMark uint32
+	hasMark    bool
 }
 
 func New() (RawSocket, error) {
@@ -20,18 +25,72 @@ func New() (RawSocket, error) {
 		return nil, fmt.Errorf("IP_HDRINCL: %w", err)
 	}
 
-	return &platformRawSocket{fd: fd}, nil
+	return &platformRawSocket{
+		fd4: fd,
+		fd6: -1,
+	}, nil
 }
 
 func (s *platformRawSocket) SendFake(conn ConnInfo, payload []byte, ttl int) error {
 	pkt := BuildPacket(conn, payload, ttl)
+	if len(pkt) == 0 {
+		return fmt.Errorf("invalid IP family or address pair")
+	}
 
-	addr := syscall.SockaddrInet4{Port: 0}
-	copy(addr.Addr[:], conn.DstIP.To4())
+	switch connIPFamily(conn) {
+	case ipFamilyIPv4:
+		addr := syscall.SockaddrInet4{Port: 0}
+		copy(addr.Addr[:], conn.DstIP.To4())
+		return syscall.Sendto(s.fd4, pkt, 0, &addr)
+	case ipFamilyIPv6:
+		if err := s.ensureIPv6Socket(); err != nil {
+			return err
+		}
+		addr := syscall.SockaddrInet6{Port: 0}
+		copy(addr.Addr[:], conn.DstIP.To16())
+		return syscall.Sendto(s.fd6, pkt, 0, &addr)
+	default:
+		return fmt.Errorf("invalid IP family or address pair")
+	}
+}
 
-	return syscall.Sendto(s.fd, pkt, 0, &addr)
+func (s *platformRawSocket) ensureIPv6Socket() error {
+	if s.fd6 >= 0 {
+		return nil
+	}
+
+	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_RAW, unix.IPPROTO_RAW)
+	if err != nil {
+		return fmt.Errorf("raw ipv6 socket: %w", err)
+	}
+	if err := unix.SetsockoptInt(fd, unix.IPPROTO_IPV6, unix.IPV6_HDRINCL, 1); err != nil {
+		unix.Close(fd)
+		return fmt.Errorf("IPV6_HDRINCL: %w", err)
+	}
+	if s.hasMark {
+		if err := unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_MARK, int(s.packetMark)); err != nil {
+			unix.Close(fd)
+			return fmt.Errorf("SO_MARK: %w", err)
+		}
+	}
+
+	s.fd6 = fd
+	return nil
 }
 
 func (s *platformRawSocket) Close() error {
-	return syscall.Close(s.fd)
+	var firstErr error
+	if s.fd4 >= 0 {
+		if err := syscall.Close(s.fd4); err != nil {
+			firstErr = err
+		}
+		s.fd4 = -1
+	}
+	if s.fd6 >= 0 {
+		if err := syscall.Close(s.fd6); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		s.fd6 = -1
+	}
+	return firstErr
 }

--- a/pkg/rawsock/rawsock_test.go
+++ b/pkg/rawsock/rawsock_test.go
@@ -204,3 +204,66 @@ func TestBuildPacket_DifferentTTL(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildPacket_IPv6HeaderAndPayload(t *testing.T) {
+	conn := ConnInfo{
+		SrcIP:   net.ParseIP("2001:db8::1"),
+		DstIP:   net.ParseIP("2001:db8::2"),
+		SrcPort: 12345,
+		DstPort: 443,
+		Seq:     1000,
+		Ack:     2000,
+	}
+	payload := []byte("ipv6-test-payload")
+	ttl := 8
+
+	pkt := BuildPacket(conn, payload, ttl)
+	if len(pkt) < 60+len(payload) {
+		t.Fatalf("packet too short: %d bytes", len(pkt))
+	}
+	if pkt[0]>>4 != 6 {
+		t.Fatalf("IP version: got %d, want 6", pkt[0]>>4)
+	}
+	if pkt[6] != 6 {
+		t.Fatalf("next header: got %d, want 6", pkt[6])
+	}
+	if pkt[7] != byte(ttl) {
+		t.Fatalf("hop limit: got %d, want %d", pkt[7], ttl)
+	}
+	if !net.IP(pkt[8:24]).Equal(conn.SrcIP.To16()) {
+		t.Fatalf("src IP: got %v, want %v", net.IP(pkt[8:24]), conn.SrcIP)
+	}
+	if !net.IP(pkt[24:40]).Equal(conn.DstIP.To16()) {
+		t.Fatalf("dst IP: got %v, want %v", net.IP(pkt[24:40]), conn.DstIP)
+	}
+	if string(pkt[60:]) != string(payload) {
+		t.Fatalf("payload: got %q, want %q", pkt[60:], payload)
+	}
+}
+
+func TestBuildPacket_IPv6TCPChecksum(t *testing.T) {
+	conn := ConnInfo{
+		SrcIP:   net.ParseIP("2001:db8::1"),
+		DstIP:   net.ParseIP("2001:db8::2"),
+		SrcPort: 12345,
+		DstPort: 443,
+		Seq:     1000,
+		Ack:     2000,
+	}
+	payload := []byte("test")
+
+	pkt := BuildPacket(conn, payload, 8)
+	tcpSeg := pkt[40:]
+	pseudo := make([]byte, 0, 40+len(tcpSeg))
+	pseudo = append(pseudo, conn.SrcIP.To16()...)
+	pseudo = append(pseudo, conn.DstIP.To16()...)
+	tcpLen := make([]byte, 4)
+	binary.BigEndian.PutUint32(tcpLen, uint32(len(tcpSeg)))
+	pseudo = append(pseudo, tcpLen...)
+	pseudo = append(pseudo, 0, 0, 0, 6)
+	pseudo = append(pseudo, tcpSeg...)
+
+	if cs := Checksum(pseudo); cs != 0 {
+		t.Fatalf("TCP checksum verification failed: got 0x%04x, want 0x0000", cs)
+	}
+}

--- a/pkg/rawsock/rawsock_windows.go
+++ b/pkg/rawsock/rawsock_windows.go
@@ -2,8 +2,86 @@
 
 package rawsock
 
-import "fmt"
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	ipProtoRaw  = 255
+	ipV6HdrIncl = 2
+)
+
+type platformRawSocket struct {
+	fd4     windows.Handle
+	fd6     windows.Handle
+	hasIPv6 bool
+}
 
 func New() (RawSocket, error) {
-	return nil, fmt.Errorf("Npcap support requires CGO build — rebuild with CGO_ENABLED=1 and Npcap installed")
+	fd, err := windows.Socket(windows.AF_INET, windows.SOCK_RAW, ipProtoRaw)
+	if err != nil {
+		return nil, fmt.Errorf("raw socket: %w", err)
+	}
+	if err := windows.SetsockoptInt(fd, windows.IPPROTO_IP, windows.IP_HDRINCL, 1); err != nil {
+		windows.Closesocket(fd)
+		return nil, fmt.Errorf("IP_HDRINCL: %w", err)
+	}
+	return &platformRawSocket{fd4: fd}, nil
+}
+
+func (s *platformRawSocket) SendFake(conn ConnInfo, payload []byte, ttl int) error {
+	pkt := BuildPacket(conn, payload, ttl)
+	if len(pkt) == 0 {
+		return fmt.Errorf("invalid IP family or address pair")
+	}
+
+	switch connIPFamily(conn) {
+	case ipFamilyIPv4:
+		addr := &windows.SockaddrInet4{}
+		copy(addr.Addr[:], conn.DstIP.To4())
+		return windows.Sendto(s.fd4, pkt, 0, addr)
+	case ipFamilyIPv6:
+		if err := s.ensureIPv6Socket(); err != nil {
+			return err
+		}
+		addr := &windows.SockaddrInet6{}
+		copy(addr.Addr[:], conn.DstIP.To16())
+		return windows.Sendto(s.fd6, pkt, 0, addr)
+	default:
+		return fmt.Errorf("invalid IP family or address pair")
+	}
+}
+
+func (s *platformRawSocket) Close() error {
+	var firstErr error
+	if err := windows.Closesocket(s.fd4); err != nil {
+		firstErr = err
+	}
+	if s.hasIPv6 {
+		if err := windows.Closesocket(s.fd6); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (s *platformRawSocket) ensureIPv6Socket() error {
+	if s.hasIPv6 {
+		return nil
+	}
+
+	fd, err := windows.Socket(windows.AF_INET6, windows.SOCK_RAW, ipProtoRaw)
+	if err != nil {
+		return fmt.Errorf("raw ipv6 socket: %w", err)
+	}
+	if err := windows.SetsockoptInt(fd, windows.IPPROTO_IPV6, ipV6HdrIncl, 1); err != nil {
+		windows.Closesocket(fd)
+		return fmt.Errorf("IPV6_HDRINCL: %w", err)
+	}
+
+	s.fd6 = fd
+	s.hasIPv6 = true
+	return nil
 }

--- a/pkg/rawsock/rawsock_windows.go
+++ b/pkg/rawsock/rawsock_windows.go
@@ -1,4 +1,4 @@
-//go:build windows && !cgo
+//go:build windows
 
 package rawsock
 
@@ -20,6 +20,20 @@ type platformRawSocket struct {
 }
 
 func New() (RawSocket, error) {
+	if sock, err, ok := tryPcapRawSocket(); ok {
+		if err == nil {
+			return sock, nil
+		}
+		native, nativeErr := newWindowsRawSocket()
+		if nativeErr == nil {
+			return native, nil
+		}
+		return nil, fmt.Errorf("pcap raw socket failed: %v; native raw socket failed: %w", err, nativeErr)
+	}
+	return newWindowsRawSocket()
+}
+
+func newWindowsRawSocket() (RawSocket, error) {
 	fd, err := windows.Socket(windows.AF_INET, windows.SOCK_RAW, ipProtoRaw)
 	if err != nil {
 		return nil, fmt.Errorf("raw socket: %w", err)

--- a/pkg/rawsock/rawsock_windows_pcap.go
+++ b/pkg/rawsock/rawsock_windows_pcap.go
@@ -36,12 +36,20 @@ func New() (RawSocket, error) {
 
 func (s *pcapRawSocket) SendFake(conn ConnInfo, payload []byte, ttl int) error {
 	ipTcp := BuildPacket(conn, payload, ttl)
+	if len(ipTcp) == 0 {
+		return fmt.Errorf("invalid IP family or address pair")
+	}
 
 	frame := make([]byte, 14+len(ipTcp))
 	copy(frame[0:6], s.dstMAC)
 	copy(frame[6:12], s.srcMAC)
-	frame[12] = 0x08
-	frame[13] = 0x00
+	if connIPFamily(conn) == ipFamilyIPv6 {
+		frame[12] = 0x86
+		frame[13] = 0xdd
+	} else {
+		frame[12] = 0x08
+		frame[13] = 0x00
+	}
 	copy(frame[14:], ipTcp)
 
 	return s.handle.WritePacketData(frame)

--- a/pkg/rawsock/rawsock_windows_pcap.go
+++ b/pkg/rawsock/rawsock_windows_pcap.go
@@ -18,20 +18,20 @@ type pcapRawSocket struct {
 	dstMAC net.HardwareAddr
 }
 
-func New() (RawSocket, error) {
+func tryPcapRawSocket() (RawSocket, error, bool) {
 	iface, err := defaultInterface()
 	if err != nil {
-		return nil, fmt.Errorf("detect interface: %w", err)
+		return nil, fmt.Errorf("detect interface: %w", err), true
 	}
 
 	handle, err := pcap.OpenLive(iface, 0, false, 100*time.Millisecond)
 	if err != nil {
-		return nil, fmt.Errorf("pcap open %s: %w (is Npcap installed?)", iface, err)
+		return nil, fmt.Errorf("pcap open %s: %w (is Npcap installed?)", iface, err), true
 	}
 
 	srcMAC, dstMAC := discoverMACs()
 
-	return &pcapRawSocket{handle: handle, srcMAC: srcMAC, dstMAC: dstMAC}, nil
+	return &pcapRawSocket{handle: handle, srcMAC: srcMAC, dstMAC: dstMAC}, nil, true
 }
 
 func (s *pcapRawSocket) SendFake(conn ConnInfo, payload []byte, ttl int) error {

--- a/pkg/rawsock/rawsock_windows_pcap_stub.go
+++ b/pkg/rawsock/rawsock_windows_pcap_stub.go
@@ -1,0 +1,7 @@
+//go:build windows && !cgo
+
+package rawsock
+
+func tryPcapRawSocket() (RawSocket, error, bool) {
+	return nil, nil, false
+}

--- a/pkg/seqtrack/seqtracker_darwin.go
+++ b/pkg/seqtrack/seqtracker_darwin.go
@@ -72,7 +72,7 @@ func GetSeqAck(conn net.Conn) (seq, ack uint32) {
 	// (typically <10ms after Dial). 500ms is a safe upper bound.
 	evt := globalSeqTracker.WaitForSeqAck(localPort, 500*time.Millisecond)
 	if evt == nil {
-		logrus.WithField("port", localPort).Warn("seq/ack fallback to placeholder — fake may be rejected by DPI")
+		logrus.WithField("port", localPort).Warn("seq/ack capture unavailable — fake may be rejected by DPI")
 		return 1, 1
 	}
 

--- a/pkg/seqtrack/seqtracker_windows.go
+++ b/pkg/seqtrack/seqtracker_windows.go
@@ -47,6 +47,7 @@ func (st *SeqTracker) Stop() {
 }
 
 var globalSeqTracker *SeqTracker
+var fallbackWarnOnce sync.Once
 
 func SetSeqTracker(st *SeqTracker) {
 	globalSeqTracker = st
@@ -66,7 +67,10 @@ func GetSeqAck(conn net.Conn) (seq, ack uint32) {
 
 	evt := globalSeqTracker.WaitForSeqAck(localPort, 500*time.Millisecond)
 	if evt == nil {
-		logrus.WithField("port", localPort).Warn("seq/ack fallback — Npcap may not be capturing")
+		fallbackWarnOnce.Do(func() {
+			logrus.Warn("seq/ack fallback active — Windows capture path missed SYN/ACK, using default sequence numbers")
+		})
+		logrus.WithField("port", localPort).Debug("seq/ack fallback used for this flow")
 		return 1, 1
 	}
 

--- a/pkg/tun/handler.go
+++ b/pkg/tun/handler.go
@@ -1,4 +1,4 @@
-//go:build (darwin || windows) && with_gvisor
+//go:build darwin || windows
 
 package tun
 

--- a/pkg/tun/manager.go
+++ b/pkg/tun/manager.go
@@ -1,4 +1,4 @@
-//go:build (darwin || windows) && with_gvisor
+//go:build darwin || windows
 
 package tun
 
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"runtime"
+	"strings"
 	"time"
 
-	"github.com/boratanrikulu/gecit/pkg/seqtrack"
 	"github.com/boratanrikulu/gecit/pkg/rawsock"
+	"github.com/boratanrikulu/gecit/pkg/seqtrack"
 	"github.com/sagernet/sing-tun"
 	"github.com/sagernet/sing/common/control"
 	singlog "github.com/sagernet/sing/common/logger"
@@ -23,6 +25,7 @@ type Config struct {
 	Ports     []uint16
 	FakeTTL   int
 	Interface string
+	Stack     string
 }
 
 type Manager struct {
@@ -38,6 +41,7 @@ type Manager struct {
 	bindControl    control.Func
 	networkMonitor tun.NetworkUpdateMonitor
 	ifaceMonitor   tun.DefaultInterfaceMonitor
+	stackName      string
 }
 
 func NewManager(cfg Config, logger *logrus.Logger) *Manager {
@@ -46,6 +50,9 @@ func NewManager(cfg Config, logger *logrus.Logger) *Manager {
 	}
 	if len(cfg.Ports) == 0 {
 		cfg.Ports = []uint16{443}
+	}
+	if strings.TrimSpace(cfg.Stack) == "" {
+		cfg.Stack = "auto"
 	}
 	ports := make(map[uint16]bool)
 	for _, p := range cfg.Ports {
@@ -76,6 +83,13 @@ func (m *Manager) Start(ctx context.Context) error {
 		return err
 	}
 
+	stackName, err := selectStackName(m.cfg.Stack)
+	if err != nil {
+		m.rawSock.Close()
+		return err
+	}
+	m.stackName = stackName
+
 	tunOpts := m.tunOptions()
 	tunDevice, err := tun.New(tunOpts)
 	if err != nil {
@@ -87,7 +101,7 @@ func (m *Manager) Start(ctx context.Context) error {
 	tunName, _ := tunDevice.Name()
 	m.logger.WithField("name", tunName).Info("TUN device created")
 
-	stack, err := tun.NewStack("gvisor", tun.StackOptions{
+	stack, err := tun.NewStack(stackName, tun.StackOptions{
 		Context:                m.ctx,
 		Tun:                    tunDevice,
 		TunOptions:             tunOpts,
@@ -119,6 +133,7 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	m.logger.WithFields(logrus.Fields{
 		"tun":   tunName,
+		"stack": stackName,
 		"ports": m.cfg.Ports,
 		"ttl":   m.cfg.FakeTTL,
 	}).Info("TUN engine active")
@@ -160,6 +175,19 @@ func (m *Manager) dialServer(network, addr string, timeout time.Duration) (net.C
 // DialContext dials via physical NIC, bypassing TUN. Exported for DoH client.
 func (m *Manager) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	return (&net.Dialer{Timeout: 5 * time.Second, Control: m.bindControl}).DialContext(ctx, network, addr)
+}
+
+func (m *Manager) StackName() string {
+	if m.stackName != "" {
+		return m.stackName
+	}
+	if normalized := strings.TrimSpace(strings.ToLower(m.cfg.Stack)); normalized != "" && normalized != "auto" {
+		return normalized
+	}
+	if tun.WithGVisor {
+		return "gvisor"
+	}
+	return "system"
 }
 
 func (m *Manager) startSeqTracker() error {
@@ -212,14 +240,41 @@ func (m *Manager) initNetworking() error {
 
 func (m *Manager) tunOptions() tun.Options {
 	return tun.Options{
-		Name:             "utun85",
+		Name:             platformTunName(),
 		Inet4Address:     []netip.Prefix{netip.MustParsePrefix("10.0.85.1/30")},
 		MTU:              tunMTU,
 		AutoRoute:        true,
 		InterfaceMonitor: m.ifaceMonitor,
 		InterfaceFinder:  m.ifaceFinder,
-		DNSServers: []netip.Addr{netip.MustParseAddr("127.0.0.1")},
+		DNSServers:       []netip.Addr{netip.MustParseAddr("127.0.0.1")},
 	}
+}
+
+func selectStackName(raw string) (string, error) {
+	stack := strings.TrimSpace(strings.ToLower(raw))
+	switch stack {
+	case "", "auto":
+		if tun.WithGVisor {
+			return "gvisor", nil
+		}
+		return "system", nil
+	case "system":
+		return "system", nil
+	case "gvisor", "mixed":
+		if !tun.WithGVisor {
+			return "", fmt.Errorf("%s stack requires build tag with_gvisor", stack)
+		}
+		return stack, nil
+	default:
+		return "", fmt.Errorf("unknown TUN stack %q", raw)
+	}
+}
+
+func platformTunName() string {
+	if runtime.GOOS == "windows" {
+		return "gecit"
+	}
+	return "utun85"
 }
 
 func detectPhysicalInterface() string {
@@ -252,4 +307,3 @@ func detectPhysicalInterface() string {
 	}
 	return ""
 }
-

--- a/pkg/tun/manager.go
+++ b/pkg/tun/manager.go
@@ -278,20 +278,21 @@ func platformTunName() string {
 }
 
 func detectPhysicalInterface() string {
+	if runtime.GOOS == "windows" {
+		if iface := detectWindowsPhysicalInterface(); iface != "" {
+			return iface
+		}
+	}
+	return detectGenericPhysicalInterface()
+}
+
+func detectGenericPhysicalInterface() string {
 	ifaces, _ := net.Interfaces()
 	for _, iface := range ifaces {
 		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
 			continue
 		}
-		name := iface.Name
-		// Skip virtual interfaces (TUN, bridge, veth, etc.)
-		for _, prefix := range []string{"utun", "bridge", "veth", "vmnet", "lo"} {
-			if len(name) >= len(prefix) && name[:len(prefix)] == prefix {
-				name = ""
-				break
-			}
-		}
-		if name == "" {
+		if isVirtualInterfaceName(iface.Name) {
 			continue
 		}
 		addrs, _ := iface.Addrs()
@@ -301,9 +302,45 @@ func detectPhysicalInterface() string {
 				continue
 			}
 			if ipv4 := ipNet.IP.To4(); ipv4 != nil && !ipv4.IsLoopback() && !ipv4.Equal(net.IPv4(10, 0, 85, 1)) {
-				return name
+				return iface.Name
 			}
 		}
 	}
 	return ""
+}
+
+func isVirtualInterfaceName(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	for _, prefix := range []string{
+		"utun",
+		"bridge",
+		"veth",
+		"vmnet",
+		"lo",
+		"vethernet",
+		"loopback",
+		"wintun",
+		"docker",
+		"br-",
+		"virbr",
+		"zt",
+		"tailscale",
+	} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	for _, fragment := range []string{
+		"default switch",
+		"hyper-v",
+		"wsl",
+		"virtual",
+		"npcap",
+		"wireguard",
+	} {
+		if strings.Contains(lower, fragment) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/tun/manager_test.go
+++ b/pkg/tun/manager_test.go
@@ -1,0 +1,55 @@
+//go:build darwin || windows
+
+package tun
+
+import (
+	"strings"
+	"testing"
+
+	singtun "github.com/sagernet/sing-tun"
+)
+
+func TestSelectStackNameAuto(t *testing.T) {
+	got, err := selectStackName("auto")
+	if err != nil {
+		t.Fatalf("selectStackName(auto) error = %v", err)
+	}
+
+	want := "system"
+	if singtun.WithGVisor {
+		want = "gvisor"
+	}
+	if got != want {
+		t.Fatalf("selectStackName(auto) = %q, want %q", got, want)
+	}
+}
+
+func TestSelectStackNameSystem(t *testing.T) {
+	got, err := selectStackName("system")
+	if err != nil {
+		t.Fatalf("selectStackName(system) error = %v", err)
+	}
+	if got != "system" {
+		t.Fatalf("selectStackName(system) = %q, want system", got)
+	}
+}
+
+func TestSelectStackNameGVisorRequirement(t *testing.T) {
+	got, err := selectStackName("gvisor")
+	if singtun.WithGVisor {
+		if err != nil {
+			t.Fatalf("selectStackName(gvisor) error = %v", err)
+		}
+		if got != "gvisor" {
+			t.Fatalf("selectStackName(gvisor) = %q, want gvisor", got)
+		}
+		return
+	}
+
+	if err == nil {
+		t.Fatal("selectStackName(gvisor) expected error without with_gvisor build tag")
+	}
+	if !strings.Contains(err.Error(), "with_gvisor") {
+		t.Fatalf("selectStackName(gvisor) error = %v, want with_gvisor hint", err)
+	}
+}

--- a/pkg/tun/manager_windows.go
+++ b/pkg/tun/manager_windows.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package tun
+
+import (
+	"net"
+
+	"golang.org/x/sys/windows"
+)
+
+var windowsRouteProbeAddrs = [][4]byte{
+	{1, 1, 1, 1},
+	{8, 8, 8, 8},
+}
+
+func detectWindowsPhysicalInterface() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	return detectWindowsBestRouteInterface(ifaces)
+}
+
+func detectWindowsBestRouteInterface(ifaces []net.Interface) string {
+	for _, addr := range windowsRouteProbeAddrs {
+		sockaddr := &windows.SockaddrInet4{Addr: addr}
+		var index uint32
+		if err := windows.GetBestInterfaceEx(sockaddr, &index); err != nil || index == 0 {
+			continue
+		}
+		if name := interfaceNameByIndex(ifaces, int(index)); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func interfaceNameByIndex(ifaces []net.Interface, index int) string {
+	for _, iface := range ifaces {
+		if iface.Index != index {
+			continue
+		}
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			return ""
+		}
+		if isVirtualInterfaceName(iface.Name) {
+			return ""
+		}
+		return iface.Name
+	}
+	return ""
+}

--- a/pkg/tun/manager_windows_test.go
+++ b/pkg/tun/manager_windows_test.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package tun
+
+import (
+	"net"
+	"testing"
+)
+
+func TestInterfaceNameByIndexPrefersUsableInterface(t *testing.T) {
+	ifaces := []net.Interface{
+		{Index: 22, Name: "vEthernet (Default Switch)", Flags: net.FlagUp | net.FlagBroadcast | net.FlagMulticast},
+		{Index: 4, Name: "Wi-Fi", Flags: net.FlagUp | net.FlagBroadcast | net.FlagMulticast | net.FlagRunning},
+	}
+
+	if got := interfaceNameByIndex(ifaces, 4); got != "Wi-Fi" {
+		t.Fatalf("interfaceNameByIndex(..., 4) = %q, want Wi-Fi", got)
+	}
+}
+
+func TestInterfaceNameByIndexRejectsVirtualInterfaces(t *testing.T) {
+	ifaces := []net.Interface{
+		{Index: 22, Name: "vEthernet (Default Switch)", Flags: net.FlagUp | net.FlagBroadcast | net.FlagMulticast},
+	}
+
+	if got := interfaceNameByIndex(ifaces, 22); got != "" {
+		t.Fatalf("interfaceNameByIndex(..., 22) = %q, want empty for virtual interface", got)
+	}
+}
+
+func TestIsVirtualInterfaceName(t *testing.T) {
+	tests := map[string]bool{
+		"Wi-Fi":                      false,
+		"Ethernet":                   false,
+		"vEthernet (Default Switch)": true,
+		"Wintun Userspace Tunnel":    true,
+		"tailscale0":                 true,
+	}
+
+	for name, want := range tests {
+		if got := isVirtualInterfaceName(name); got != want {
+			t.Fatalf("isVirtualInterfaceName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}


### PR DESCRIPTION

  - add IPv6/raw socket core helpers required by the Windows path
  - add no-cgo Windows runtime and system TUN stack support
  - add dual-stack raw capture fallback on Windows
  - fall back from pcap to native paths when Npcap is missing
  - edit/develop Windows uplink detection, cleanup route removal, and seq/ack fallback logging

  Validation:
  - go test ./...
  - go test -tags with_gvisor ./...
  - elevated Windows runtime validation for system, gvisor, and mixed stacks
  