### PR TITLE
Auto-TTL Calculation for Windows and Darwin

### DIFF
--- a/cmd/gecit/app/run.go
+++ b/cmd/gecit/app/run.go
@@ -19,7 +19,7 @@ var runCmd = &cobra.Command{
 }
 
 func init() {
-	runCmd.Flags().Int("fake-ttl", 8, "TTL for fake packets (reaches DPI, not server)")
+	runCmd.Flags().Int("fake-ttl", 0, "TTL for fake packets sent to DPI (0 = auto-detect from server SYN-ACK)")
 	runCmd.Flags().Bool("doh", true, "enable built-in DoH DNS resolver")
 	runCmd.Flags().String("doh-upstream", "cloudflare", "DoH upstream: preset (cloudflare,google,quad9,nextdns,adguard) or URL")
 	runCmd.Flags().Int("mss", 40, "TCP MSS for ClientHello fragmentation (Linux only)")

--- a/pkg/capture/capture_darwin.go
+++ b/pkg/capture/capture_darwin.go
@@ -103,12 +103,13 @@ func (c *pcapCapture) processPacket(packet gopacket.Packet, cb Callback) {
 	ip := ipLayer.(*layers.IPv4)
 
 	evt := ConnectionEvent{
-		SrcIP:   append(net.IP{}, ip.DstIP.To4()...), // our IP
-		DstIP:   append(net.IP{}, ip.SrcIP.To4()...), // server IP
-		SrcPort: uint16(tcp.DstPort),                 // our port
-		DstPort: uint16(tcp.SrcPort),                 // server port (443)
-		Seq:     tcp.Ack,                             // our snd_nxt
-		Ack:     tcp.Seq + 1,                         // our rcv_nxt
+		SrcIP:     append(net.IP{}, ip.DstIP.To4()...), // our IP
+		DstIP:     append(net.IP{}, ip.SrcIP.To4()...), // server IP
+		SrcPort:   uint16(tcp.DstPort),                 // our port
+		DstPort:   uint16(tcp.SrcPort),                 // server port (443)
+		Seq:       tcp.Ack,                             // our snd_nxt
+		Ack:       tcp.Seq + 1,                         // our rcv_nxt
+		ServerTTL: ip.TTL,                              // server TTL
 	}
 
 	cb(evt)

--- a/pkg/capture/capture_windows_pcap.go
+++ b/pkg/capture/capture_windows_pcap.go
@@ -107,12 +107,13 @@ func (c *pcapCapture) processPacket(packet gopacket.Packet, cb Callback) {
 	ip := ipLayer.(*layers.IPv4)
 
 	evt := ConnectionEvent{
-		SrcIP:   append(net.IP{}, ip.DstIP.To4()...),
-		DstIP:   append(net.IP{}, ip.SrcIP.To4()...),
-		SrcPort: uint16(tcp.DstPort),
-		DstPort: uint16(tcp.SrcPort),
-		Seq:     tcp.Ack,
-		Ack:     tcp.Seq + 1,
+		SrcIP:     append(net.IP{}, ip.DstIP.To4()...),
+		DstIP:     append(net.IP{}, ip.SrcIP.To4()...),
+		SrcPort:   uint16(tcp.DstPort),
+		DstPort:   uint16(tcp.SrcPort),
+		Seq:       tcp.Ack,
+		Ack:       tcp.Seq + 1,
+		ServerTTL: ip.TTL,
 	}
 
 	cb(evt)

--- a/pkg/engine/config.go
+++ b/pkg/engine/config.go
@@ -19,7 +19,7 @@ func DefaultConfig() Config {
 		RestoreAfterBytes: 600,
 		Ports:             []uint16{443},
 		CgroupPath:        "/sys/fs/cgroup",
-		FakeTTL:           8,
+		FakeTTL:           0,
 		DoHEnabled:        true,
 		DoHUpstream:       "cloudflare",
 	}

--- a/pkg/engine/config_test.go
+++ b/pkg/engine/config_test.go
@@ -13,7 +13,7 @@ func TestDefaultConfig(t *testing.T) {
 		{"MSS", cfg.MSS, 40},
 		{"RestoreMSS", cfg.RestoreMSS, 0},
 		{"RestoreAfterBytes", cfg.RestoreAfterBytes, 600},
-		{"FakeTTL", cfg.FakeTTL, 8},
+		{"FakeTTL", cfg.FakeTTL, 0},
 		{"DoHEnabled", cfg.DoHEnabled, true},
 		{"DoHUpstream", cfg.DoHUpstream, "cloudflare"},
 		{"CgroupPath", cfg.CgroupPath, "/sys/fs/cgroup"},

--- a/pkg/rawsock/rawsock.go
+++ b/pkg/rawsock/rawsock.go
@@ -8,12 +8,13 @@ import (
 
 // ConnInfo holds connection details for crafting fake packets.
 type ConnInfo struct {
-	SrcIP   net.IP
-	DstIP   net.IP
-	SrcPort uint16
-	DstPort uint16
-	Seq     uint32 // TCP sequence number the real data will use
-	Ack     uint32 // TCP ACK number (rcv_nxt from the connection)
+	SrcIP     net.IP
+	DstIP     net.IP
+	SrcPort   uint16
+	DstPort   uint16
+	Seq       uint32 // TCP sequence number the real data will use
+	Ack       uint32 // TCP ACK number (rcv_nxt from the connection)
+	ServerTTL uint8  // TTL value of the SYN-ACK packet received from the server. 0 means unknown.
 }
 
 // RawSocket sends crafted TCP packets with custom TTL.

--- a/pkg/rawsock/rawsock_test.go
+++ b/pkg/rawsock/rawsock_test.go
@@ -204,3 +204,36 @@ func TestBuildPacket_DifferentTTL(t *testing.T) {
 		}
 	}
 }
+
+// This verifies that ServerTTL is pure metadata stored on ConnInfo for caller use.
+// It must not influence the constructed packet bytes.
+// The wire TTL comes exclusively from the ttl int parameter.
+func TestBuildPacket_ServerTTLIsMetadata(t *testing.T) {
+	base := ConnInfo{
+		SrcIP:   net.IPv4(10, 0, 0, 1),
+		DstIP:   net.IPv4(1, 1, 1, 1),
+		SrcPort: 5000,
+		DstPort: 443,
+		Seq:     100,
+		Ack:     200,
+	}
+
+	payload := []byte("probe")
+	wireTTL := 8
+
+	pktNoServerTTL := BuildPacket(base, payload, wireTTL)
+
+	withServerTTL := base
+	withServerTTL.ServerTTL = 60
+
+	pktWithServerTTL := BuildPacket(withServerTTL, payload, wireTTL)
+
+	if len(pktNoServerTTL) != len(pktWithServerTTL) {
+		t.Fatalf("packet length differs: %d vs %d", len(pktNoServerTTL), len(pktWithServerTTL))
+	}
+	for i := range pktNoServerTTL {
+		if pktNoServerTTL[i] != pktWithServerTTL[i] {
+			t.Errorf("byte %d differs: 0x%02x vs 0x%02x — ServerTTL leaked into packet", i, pktNoServerTTL[i], pktWithServerTTL[i])
+		}
+	}
+}

--- a/pkg/seqtrack/seqtracker_darwin.go
+++ b/pkg/seqtrack/seqtracker_darwin.go
@@ -54,17 +54,23 @@ func SetSeqTracker(st *SeqTracker) {
 	globalSeqTracker = st
 }
 
-// GetSeqAck returns the real TCP seq/ack for a connection by waiting for
-// pcap to capture the SYN-ACK.
-func GetSeqAck(conn net.Conn, defaultTTL uint8) (seq, ack uint32, fakeTTL uint8) {
-	// fallback to default ttl in all non-successful cases
+// GetSeqAck returns the real TCP seq/ack for a connection by waiting for pcap to capture the SYN-ACK.
+// userProvidedTTL==0 means auto-calculate the fake TTL from the server's SYN-ACK; any non-zero value overrides auto-calculation.
+func GetSeqAck(conn net.Conn, userProvidedTTL uint8) (seq, ack uint32, fakeTTL uint8) {
+	const tempFallbackTTL uint8 = 8
+
+	TTL := userProvidedTTL
+	if TTL == 0 {
+		TTL = tempFallbackTTL
+	}
+
 	if globalSeqTracker == nil {
-		return 1, 1, defaultTTL
+		return 1, 1, TTL
 	}
 
 	tcpConn, ok := conn.(*net.TCPConn)
 	if !ok {
-		return 1, 1, defaultTTL
+		return 1, 1, TTL
 	}
 
 	localPort := uint16(tcpConn.LocalAddr().(*net.TCPAddr).Port)
@@ -74,11 +80,16 @@ func GetSeqAck(conn net.Conn, defaultTTL uint8) (seq, ack uint32, fakeTTL uint8)
 	evt := globalSeqTracker.WaitForSeqAck(localPort, 500*time.Millisecond)
 	if evt == nil {
 		logrus.WithField("port", localPort).Warn("seq/ack fallback to placeholder — fake may be rejected by DPI")
-		return 1, 1, defaultTTL
+		return 1, 1, TTL
 	}
 
 	if evt.ServerTTL == 0 {
-		return 1, 1, defaultTTL
+		return 1, 1, TTL
+	}
+
+	// user-specified TTL takes precedence over auto-calculation.
+	if userProvidedTTL != 0 {
+		return evt.Seq, evt.Ack, userProvidedTTL
 	}
 	return evt.Seq, evt.Ack, CalculateFakeTTL(evt.ServerTTL)
 }

--- a/pkg/seqtrack/seqtracker_darwin.go
+++ b/pkg/seqtrack/seqtracker_darwin.go
@@ -56,14 +56,15 @@ func SetSeqTracker(st *SeqTracker) {
 
 // GetSeqAck returns the real TCP seq/ack for a connection by waiting for
 // pcap to capture the SYN-ACK.
-func GetSeqAck(conn net.Conn) (seq, ack uint32) {
+func GetSeqAck(conn net.Conn, defaultTTL uint8) (seq, ack uint32, fakeTTL uint8) {
+	// fallback to default ttl in all non-successful cases
 	if globalSeqTracker == nil {
-		return 1, 1
+		return 1, 1, defaultTTL
 	}
 
 	tcpConn, ok := conn.(*net.TCPConn)
 	if !ok {
-		return 1, 1
+		return 1, 1, defaultTTL
 	}
 
 	localPort := uint16(tcpConn.LocalAddr().(*net.TCPAddr).Port)
@@ -73,8 +74,11 @@ func GetSeqAck(conn net.Conn) (seq, ack uint32) {
 	evt := globalSeqTracker.WaitForSeqAck(localPort, 500*time.Millisecond)
 	if evt == nil {
 		logrus.WithField("port", localPort).Warn("seq/ack fallback to placeholder — fake may be rejected by DPI")
-		return 1, 1
+		return 1, 1, defaultTTL
 	}
 
-	return evt.Seq, evt.Ack
+	if evt.ServerTTL == 0 {
+		return 1, 1, defaultTTL
+	}
+	return evt.Seq, evt.Ack, CalculateFakeTTL(evt.ServerTTL)
 }

--- a/pkg/seqtrack/seqtracker_darwin_test.go
+++ b/pkg/seqtrack/seqtracker_darwin_test.go
@@ -65,7 +65,8 @@ func TestGetSeqAck_EventFound_WithServerTTL(t *testing.T) {
 	})
 	globalSeqTracker = st
 
-	seq, ack, fakeTTL := GetSeqAck(conn, 64)
+	// defaultTTL=0 → auto mode: CalculateFakeTTL(serverTTL=60) = 3
+	seq, ack, fakeTTL := GetSeqAck(conn, 0)
 
 	if seq != 9999 {
 		t.Errorf("seq: got %d, want 9999", seq)
@@ -75,6 +76,47 @@ func TestGetSeqAck_EventFound_WithServerTTL(t *testing.T) {
 	}
 	if fakeTTL != 3 {
 		t.Errorf("fakeTTL: got %d, want 3 (CalculateFakeTTL(60))", fakeTTL)
+	}
+}
+
+func TestGetSeqAck_UserOverride_SkipsAutoCalc(t *testing.T) {
+	old := globalSeqTracker
+	defer func() { globalSeqTracker = old }()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	localPort := uint16(conn.LocalAddr().(*net.TCPAddr).Port)
+
+	st := &SeqTracker{}
+	st.conns.Store(localPort, capture.ConnectionEvent{
+		SrcPort:   localPort,
+		Seq:       9999,
+		Ack:       1111,
+		ServerTTL: 60, // CalculateFakeTTL would give 3, but override wins
+	})
+	globalSeqTracker = st
+
+	// non-zero defaultTTL = user override: auto-calculation must be skipped
+	seq, ack, fakeTTL := GetSeqAck(conn, 64)
+
+	if seq != 9999 {
+		t.Errorf("seq: got %d, want 9999", seq)
+	}
+	if ack != 1111 {
+		t.Errorf("ack: got %d, want 1111", ack)
+	}
+	if fakeTTL != 64 {
+		t.Errorf("fakeTTL: got %d, want 64 (user override)", fakeTTL)
 	}
 }
 

--- a/pkg/seqtrack/seqtracker_darwin_test.go
+++ b/pkg/seqtrack/seqtracker_darwin_test.go
@@ -1,0 +1,143 @@
+package seqtrack
+
+import (
+	"net"
+	"testing"
+
+	"github.com/boratanrikulu/gecit/pkg/capture"
+)
+
+// mockConn implements net.Conn but is not *net.TCPConn.
+// This is only used to exercise the type-assertion guard in GetSeqAck.
+type mockConn struct{ net.Conn }
+
+func TestGetSeqAck_NilTracker(t *testing.T) {
+	old := globalSeqTracker
+	defer func() { globalSeqTracker = old }()
+
+	globalSeqTracker = nil
+
+	seq, ack, fakeTTL := GetSeqAck(&mockConn{}, 42)
+	if seq != 1 || ack != 1 || fakeTTL != 42 {
+		t.Errorf("GetSeqAck(nil tracker) = (%d, %d, %d), want (1, 1, 42)", seq, ack, fakeTTL)
+	}
+}
+
+func TestGetSeqAck_NonTCPConn(t *testing.T) {
+	old := globalSeqTracker
+	defer func() { globalSeqTracker = old }()
+
+	globalSeqTracker = &SeqTracker{} // non-nil, but conn fails type assertion here.
+
+	seq, ack, fakeTTL := GetSeqAck(&mockConn{}, 99)
+	if seq != 1 || ack != 1 || fakeTTL != 99 {
+		t.Errorf("GetSeqAck(non-TCPConn) = (%d, %d, %d), want (1, 1, 99)", seq, ack, fakeTTL)
+	}
+}
+
+func TestGetSeqAck_EventFound_WithServerTTL(t *testing.T) {
+	old := globalSeqTracker
+	defer func() { globalSeqTracker = old }()
+
+	// establish a loopback TCP connection first, so we have a real *net.TCPConn
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	localPort := uint16(conn.LocalAddr().(*net.TCPAddr).Port)
+
+	// fill the tracker as if pcap had captured the SYN-ACK.
+	// serverTTL=60 -> hops=4 -> CalculateFakeTTL=3
+	st := &SeqTracker{}
+	st.conns.Store(localPort, capture.ConnectionEvent{
+		SrcPort:   localPort,
+		Seq:       9999,
+		Ack:       1111,
+		ServerTTL: 60,
+	})
+	globalSeqTracker = st
+
+	seq, ack, fakeTTL := GetSeqAck(conn, 64)
+
+	if seq != 9999 {
+		t.Errorf("seq: got %d, want 9999", seq)
+	}
+	if ack != 1111 {
+		t.Errorf("ack: got %d, want 1111", ack)
+	}
+	if fakeTTL != 3 {
+		t.Errorf("fakeTTL: got %d, want 3 (CalculateFakeTTL(60))", fakeTTL)
+	}
+}
+
+func TestGetSeqAck_EventFound_ZeroServerTTL(t *testing.T) {
+	old := globalSeqTracker
+	defer func() { globalSeqTracker = old }()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	localPort := uint16(conn.LocalAddr().(*net.TCPAddr).Port)
+
+	// serverTTL=0 means unknown. GetSeqAck must fall back to defaults.
+	st := &SeqTracker{}
+	st.conns.Store(localPort, capture.ConnectionEvent{
+		SrcPort:   localPort,
+		Seq:       9999,
+		Ack:       1111,
+		ServerTTL: 0,
+	})
+	globalSeqTracker = st
+
+	seq, ack, fakeTTL := GetSeqAck(conn, 55)
+
+	if seq != 1 || ack != 1 || fakeTTL != 55 {
+		t.Errorf("GetSeqAck(ServerTTL=0) = (%d, %d, %d), want (1, 1, 55)", seq, ack, fakeTTL)
+	}
+}
+
+func TestGetSeqAck_NoEvent_FallsBack(t *testing.T) {
+	old := globalSeqTracker
+	defer func() { globalSeqTracker = old }()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// İf the tracker exists but has no event for this port, WaitForSeqAck times out.
+	// we shorten the wait by not pre-populating the map,
+	// but the 500 ms timeout in GetSeqAck will still fire. that's why this test is slow.
+	// if this becomes a problem, extract the timeout as a parameter.
+	globalSeqTracker = &SeqTracker{}
+
+	seq, ack, fakeTTL := GetSeqAck(conn, 77)
+
+	if seq != 1 || ack != 1 || fakeTTL != 77 {
+		t.Errorf("GetSeqAck(no event) = (%d, %d, %d), want (1, 1, 77)", seq, ack, fakeTTL)
+	}
+}

--- a/pkg/seqtrack/seqtracker_linux.go
+++ b/pkg/seqtrack/seqtracker_linux.go
@@ -13,6 +13,6 @@ func NewSeqTracker(_ string, _ []uint16) (*SeqTracker, error) {
 
 func SetSeqTracker(_ *SeqTracker) {}
 
-func GetSeqAck(_ net.Conn) (seq, ack uint32) { return 1, 1 }
+func GetSeqAck(_ net.Conn, _ uint8) (seq, ack uint32, fakeTTL uint8) { return 1, 1, 1 }
 
 func (st *SeqTracker) Stop() {}

--- a/pkg/seqtrack/seqtracker_windows.go
+++ b/pkg/seqtrack/seqtracker_windows.go
@@ -52,15 +52,21 @@ func SetSeqTracker(st *SeqTracker) {
 	globalSeqTracker = st
 }
 
-func GetSeqAck(conn net.Conn, defaultTTL uint8) (seq, ack uint32, fakeTTL uint8) {
-	// fallback to default TTL in all non-successful cases
+func GetSeqAck(conn net.Conn, userProvidedTTL uint8) (seq, ack uint32, fakeTTL uint8) {
+	const tempFallbackTTL uint8 = 8
+
+	TTL := userProvidedTTL
+	if TTL == 0 {
+		TTL = tempFallbackTTL
+	}
+
 	if globalSeqTracker == nil {
-		return 1, 1, defaultTTL
+		return 1, 1, TTL
 	}
 
 	tcpConn, ok := conn.(*net.TCPConn)
 	if !ok {
-		return 1, 1, defaultTTL
+		return 1, 1, TTL
 	}
 
 	localPort := uint16(tcpConn.LocalAddr().(*net.TCPAddr).Port)
@@ -68,11 +74,16 @@ func GetSeqAck(conn net.Conn, defaultTTL uint8) (seq, ack uint32, fakeTTL uint8)
 	evt := globalSeqTracker.WaitForSeqAck(localPort, 500*time.Millisecond)
 	if evt == nil {
 		logrus.WithField("port", localPort).Warn("seq/ack fallback — Npcap may not be capturing")
-		return 1, 1, defaultTTL
+		return 1, 1, TTL
 	}
 
 	if evt.ServerTTL == 0 {
-		return 1, 1, defaultTTL
+		return 1, 1, TTL
+	}
+
+	// user-specified TTL takes precedence over auto-calculation.
+	if userProvidedTTL != 0 {
+		return evt.Seq, evt.Ack, userProvidedTTL
 	}
 	return evt.Seq, evt.Ack, CalculateFakeTTL(evt.ServerTTL)
 }

--- a/pkg/seqtrack/seqtracker_windows.go
+++ b/pkg/seqtrack/seqtracker_windows.go
@@ -52,14 +52,15 @@ func SetSeqTracker(st *SeqTracker) {
 	globalSeqTracker = st
 }
 
-func GetSeqAck(conn net.Conn) (seq, ack uint32) {
+func GetSeqAck(conn net.Conn, defaultTTL uint8) (seq, ack uint32, fakeTTL uint8) {
+	// fallback to default TTL in all non-successful cases
 	if globalSeqTracker == nil {
-		return 1, 1
+		return 1, 1, defaultTTL
 	}
 
 	tcpConn, ok := conn.(*net.TCPConn)
 	if !ok {
-		return 1, 1
+		return 1, 1, defaultTTL
 	}
 
 	localPort := uint16(tcpConn.LocalAddr().(*net.TCPAddr).Port)
@@ -67,8 +68,11 @@ func GetSeqAck(conn net.Conn) (seq, ack uint32) {
 	evt := globalSeqTracker.WaitForSeqAck(localPort, 500*time.Millisecond)
 	if evt == nil {
 		logrus.WithField("port", localPort).Warn("seq/ack fallback — Npcap may not be capturing")
-		return 1, 1
+		return 1, 1, defaultTTL
 	}
 
-	return evt.Seq, evt.Ack
+	if evt.ServerTTL == 0 {
+		return 1, 1, defaultTTL
+	}
+	return evt.Seq, evt.Ack, CalculateFakeTTL(evt.ServerTTL)
 }

--- a/pkg/seqtrack/ttl.go
+++ b/pkg/seqtrack/ttl.go
@@ -1,0 +1,23 @@
+package seqtrack
+
+// This function calculates the TTL for our own spoofed packets, based on the server's TTL which is present in the initial SYN-ACK packet.
+// Some common operating system defaults are 64 for Linux/macOS, 128 for Windows, and 255 for some routers and Solaris.
+// We assume the closest default >= serverTTL is the origin, then subtract one extra hop for the DPI box itself.
+func CalculateFakeTTL(serverTTL uint8) uint8 {
+	hops := GetOSDefaultTTL(serverTTL) - serverTTL
+	if hops <= 1 {
+		return 1
+	}
+	return hops - 1
+}
+
+func GetOSDefaultTTL(ttl uint8) uint8 {
+	switch {
+	case ttl <= 64:
+		return 64
+	case ttl <= 128:
+		return 128
+	default: // since uint8 guarantees <= 255...
+		return 255
+	}
+}

--- a/pkg/seqtrack/ttl_test.go
+++ b/pkg/seqtrack/ttl_test.go
@@ -1,0 +1,98 @@
+package seqtrack
+
+import "testing"
+
+func TestGetOSDefaultTTL(t *testing.T) {
+	tests := []struct {
+		name string
+		ttl  uint8
+		want uint8
+	}{
+		// linux/macOS bucket: [0, 64]
+		{"zero", 0, 64},
+		{"one", 1, 64},
+		{"63", 63, 64},
+		{"64_boundary", 64, 64},
+		// windows bucket: (64, 128]
+		{"65", 65, 128},
+		{"127", 127, 128},
+		{"128_boundary", 128, 128},
+		// solaris/router bucket: (128, 255]
+		{"129", 129, 255},
+		{"254", 254, 255},
+		{"255_max", 255, 255},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetOSDefaultTTL(tt.ttl)
+			if got != tt.want {
+				t.Errorf("GetOSDefaultTTL(%d) = %d, want %d", tt.ttl, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalculateFakeTTL(t *testing.T) {
+	// hops = GetOSDefaultTTL(s) - s --->> fakeTTL = hops - 1
+	// when hops <= 1, the function clamps the value to 1 (minimum TTL to be seen by DPI).
+	tests := []struct {
+		name      string
+		serverTTL uint8
+		want      uint8
+	}{
+		// linux/macOS origin (default 64): hops = 64 - serverTTL
+		{"linux_at_origin_64", 64, 1}, // hops=0, clamp -> 1
+		{"linux_1hop_63", 63, 1},      // hops=1, clamp -> 1
+		{"linux_2hops_62", 62, 1},     // hops=2, hops-1=1
+		{"linux_3hops_61", 61, 2},     // hops=3, hops-1=2
+		{"linux_4hops_60", 60, 3},     // hops=4, hops-1=3
+		{"linux_many_hops_1", 1, 62},  // hops=63, hops-1=62
+
+		// windows origin (default 128): hops = 128 - serverTTL
+		{"windows_at_origin_128", 128, 1}, // hops=0, clamp -> 1
+		{"windows_1hop_127", 127, 1},      // hops=1, clamp -> 1
+		{"windows_2hops_126", 126, 1},     // hops=2, hops-1=1
+		{"windows_8hops_120", 120, 7},     // hops=8, hops-1=7
+		{"windows_many_hops_65", 65, 62},  // hops=63, hops-1=62
+
+		// solaris/router origin (default 255): hops = 255 - serverTTL
+		{"solaris_at_origin_255", 255, 1},   // hops=0, clamp -> 1
+		{"solaris_1hop_254", 254, 1},        // hops=1, clamp -> 1
+		{"solaris_2hops_253", 253, 1},       // hops=2, hops-1=1
+		{"solaris_5hops_250", 250, 4},       // hops=5, hops-1=4
+		{"solaris_many_hops_129", 129, 125}, // hops=126, hops-1=125
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalculateFakeTTL(tt.serverTTL)
+			if got != tt.want {
+				t.Errorf("CalculateFakeTTL(%d) = %d, want %d", tt.serverTTL, got, tt.want)
+			}
+		})
+	}
+}
+
+// this verifies the safety invariant: a fake TTL of zero would be silently dropped by the kernel
+// before leaving the NIC, so the function must always return at least 1.
+func TestCalculateFakeTTL_NeverZero(t *testing.T) {
+	for i := 0; i <= 255; i++ {
+		got := CalculateFakeTTL(uint8(i))
+		if got == 0 {
+			t.Errorf("CalculateFakeTTL(%d) = 0: fake TTL must never be zero", i)
+		}
+	}
+}
+
+// this verifies the core assumption that the returned default is always >= the input TTL.
+// CalculateFakeTTL relies on this to avoid uint8 underflow in the subtraction.
+func TestGetOSDefaultTTL_AlwaysGTE(t *testing.T) {
+	for i := 0; i <= 255; i++ {
+		ttl := uint8(i)
+		def := GetOSDefaultTTL(ttl)
+		if def < ttl {
+			t.Errorf("GetOSDefaultTTL(%d) = %d < input: would underflow in CalculateFakeTTL", ttl, def)
+		}
+	}
+}

--- a/pkg/tun/handler.go
+++ b/pkg/tun/handler.go
@@ -11,8 +11,8 @@ import (
 
 	gecitdns "github.com/boratanrikulu/gecit/pkg/dns"
 	"github.com/boratanrikulu/gecit/pkg/fake"
-	"github.com/boratanrikulu/gecit/pkg/seqtrack"
 	"github.com/boratanrikulu/gecit/pkg/rawsock"
+	"github.com/boratanrikulu/gecit/pkg/seqtrack"
 	singtun "github.com/sagernet/sing-tun"
 	"github.com/sagernet/sing/common/buf"
 	M "github.com/sagernet/sing/common/metadata"
@@ -80,7 +80,7 @@ func (h *handler) injectAndForward(appConn, serverConn net.Conn, dst string) {
 		dst = fmt.Sprintf("%s:%d", sni, serverConn.RemoteAddr().(*net.TCPAddr).Port)
 	}
 
-	seq, ack := seqtrack.GetSeqAck(serverConn)
+	seq, ack, fakeTTL := seqtrack.GetSeqAck(serverConn, uint8(h.mgr.cfg.FakeTTL))
 
 	serverTCP, ok1 := serverConn.LocalAddr().(*net.TCPAddr)
 	remoteTCP, ok2 := serverConn.RemoteAddr().(*net.TCPAddr)
@@ -95,13 +95,13 @@ func (h *handler) injectAndForward(appConn, serverConn net.Conn, dst string) {
 	}
 
 	for i := 0; i < 3; i++ {
-		if err := h.mgr.rawSock.SendFake(connInfo, fake.TLSClientHello, h.mgr.cfg.FakeTTL); err != nil {
+		if err := h.mgr.rawSock.SendFake(connInfo, fake.TLSClientHello, int(fakeTTL)); err != nil {
 			h.mgr.logger.WithError(err).Warn("SendFake failed")
 			break
 		}
 	}
 	h.mgr.logger.WithFields(logrus.Fields{
-		"dst": dst, "seq": seq, "ack": ack, "ttl": h.mgr.cfg.FakeTTL,
+		"dst": dst, "seq": seq, "ack": ack, "ttl": fakeTTL, "ttl_auto_inferred": h.mgr.cfg.FakeTTL != int(fakeTTL),
 	}).Info("fake ClientHellos injected")
 
 	// Let fakes reach DPI before the real ClientHello.

--- a/pkg/tun/manager.go
+++ b/pkg/tun/manager.go
@@ -41,9 +41,6 @@ type Manager struct {
 }
 
 func NewManager(cfg Config, logger *logrus.Logger) *Manager {
-	if cfg.FakeTTL == 0 {
-		cfg.FakeTTL = 8
-	}
 	if len(cfg.Ports) == 0 {
 		cfg.Ports = []uint16{443}
 	}


### PR DESCRIPTION
### Core changes
* Added a `ServerTTL` field to `ConnInfo` and `ConnectionEvent` to track the TTL value from the server's SYN-ACK packet. This value is passed through the capture and raw socket layers. 
* Updated the `GetSeqAck` function (and its platform-specific implementations) to return the sequence number, acknowledgment number, and a "fake TTL" value, which is automatically calculated from the observed `ServerTTL` when available, or falls back to a configured default otherwise. 

### New Fake TTL calculation algorithm
* Added a new `CalculateFakeTTL` function to calculate the original server's default TTL, estimate the hop count, and subtract one extra hop for the DPI device itself. The function ensures the returned TTL is always at least 1.

### Integration
* Modified the TUN handler to use the automatically inferred TTL for fake packet injection, and to log whether the TTL was auto-inferred or set by config. 

### Testing
* Added unit tests for the TTL calculation logic and all fallback scenarios in `GetSeqAck`.