### PR TITLE
Add one-line installer + fix Linux cleanup no-op

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,30 @@ Additionally, some ISPs poison DNS responses. gecit includes a built-in DoH (DNS
 
 ## Installation
 
-### Pre-built binaries
+### Quick install (Linux, recommended)
+
+One line — detects arch, verifies SHA256, installs to `/usr/local/bin`, sets up a systemd service, enables and starts it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/boratanrikulu/gecit/main/scripts/install.sh | sudo bash
+```
+
+Optional flags and env vars:
+
+```bash
+# Pin a specific version
+curl -fsSL https://raw.githubusercontent.com/boratanrikulu/gecit/main/scripts/install.sh | sudo VERSION=v0.1.4 bash
+
+# Install but don't start the service
+curl -fsSL https://raw.githubusercontent.com/boratanrikulu/gecit/main/scripts/install.sh | sudo bash -s -- --no-start
+
+# Uninstall (stops + disables service, runs gecit cleanup, removes binary and unit file)
+curl -fsSL https://raw.githubusercontent.com/boratanrikulu/gecit/main/scripts/install.sh | sudo bash -s -- --uninstall
+```
+
+The installer requires Linux kernel 5.10+, systemd, and `amd64` or `arm64`. After installation, customize CLI flags (e.g. `--fake-ttl`, `--doh-upstream`) with `sudo systemctl edit gecit`.
+
+### Pre-built binaries (manual)
 
 Download from [releases](https://github.com/boratanrikulu/gecit/releases):
 

--- a/cmd/gecit/app/cleanup_linux.go
+++ b/cmd/gecit/app/cleanup_linux.go
@@ -1,5 +1,10 @@
 package app
 
+import gecitdns "github.com/boratanrikulu/gecit/pkg/dns"
+
 func platformCleanup() bool {
-	return false
+	if !gecitdns.SystemDNSNeedsRestore() {
+		return false
+	}
+	return gecitdns.RestoreSystemDNS() == nil
 }

--- a/pkg/dns/system_linux.go
+++ b/pkg/dns/system_linux.go
@@ -6,15 +6,15 @@ import (
 	"strings"
 )
 
-const resolvConf = "/etc/resolv.conf"
+var resolvConfPath = "/etc/resolv.conf"
 
 // SetSystemDNS comments out existing nameservers and adds 127.0.0.1.
 // Original lines are preserved as "# gecit-saved: ..." so they survive
 // a crash — RestoreSystemDNS (or manual edit) can recover them.
 func SetSystemDNS() error {
-	orig, err := os.ReadFile(resolvConf)
+	orig, err := os.ReadFile(resolvConfPath)
 	if err != nil {
-		return fmt.Errorf("read %s: %w", resolvConf, err)
+		return fmt.Errorf("read %s: %w", resolvConfPath, err)
 	}
 
 	var lines []string
@@ -33,14 +33,27 @@ func SetSystemDNS() error {
 		}
 	}
 
-	return os.WriteFile(resolvConf, []byte(strings.Join(lines, "\n")+"\n"), 0644)
+	return os.WriteFile(resolvConfPath, []byte(strings.Join(lines, "\n")+"\n"), 0644)
+}
+
+// SystemDNSNeedsRestore reports whether /etc/resolv.conf contains gecit-managed
+// state left behind by SetSystemDNS.
+func SystemDNSNeedsRestore() bool {
+	data, err := os.ReadFile(resolvConfPath)
+	if err != nil {
+		return false
+	}
+	return hasGecitDNSState(data)
 }
 
 // RestoreSystemDNS uncomments the original nameservers and removes gecit lines.
 func RestoreSystemDNS() error {
-	data, err := os.ReadFile(resolvConf)
+	data, err := os.ReadFile(resolvConfPath)
 	if err != nil {
 		return err
+	}
+	if !hasGecitDNSState(data) {
+		return nil
 	}
 
 	var lines []string
@@ -62,5 +75,15 @@ func RestoreSystemDNS() error {
 		lines = append(lines, "nameserver 8.8.8.8") // safe fallback
 	}
 
-	return os.WriteFile(resolvConf, []byte(strings.Join(lines, "\n")+"\n"), 0644)
+	return os.WriteFile(resolvConfPath, []byte(strings.Join(lines, "\n")+"\n"), 0644)
+}
+
+func hasGecitDNSState(data []byte) bool {
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "# gecit:") || strings.HasPrefix(trimmed, "# gecit-saved: ") {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/dns/system_linux_test.go
+++ b/pkg/dns/system_linux_test.go
@@ -1,0 +1,70 @@
+//go:build linux
+
+package dns
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func withTestResolvConf(t *testing.T, contents string) string {
+	t.Helper()
+
+	origPath := resolvConfPath
+	path := filepath.Join(t.TempDir(), "resolv.conf")
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("write test resolv.conf: %v", err)
+	}
+
+	resolvConfPath = path
+	t.Cleanup(func() {
+		resolvConfPath = origPath
+	})
+
+	return path
+}
+
+func TestRestoreSystemDNSRestoresGecitManagedState(t *testing.T) {
+	path := withTestResolvConf(t, "nameserver 1.1.1.1\nsearch lan\n")
+
+	if err := SetSystemDNS(); err != nil {
+		t.Fatalf("SetSystemDNS: %v", err)
+	}
+	if !SystemDNSNeedsRestore() {
+		t.Fatal("SystemDNSNeedsRestore() = false, want true")
+	}
+
+	if err := RestoreSystemDNS(); err != nil {
+		t.Fatalf("RestoreSystemDNS: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read restored resolv.conf: %v", err)
+	}
+	want := "nameserver 1.1.1.1\nsearch lan\n"
+	if string(got) != want {
+		t.Fatalf("restored resolv.conf:\n got %q\nwant %q", string(got), want)
+	}
+	if SystemDNSNeedsRestore() {
+		t.Fatal("SystemDNSNeedsRestore() = true after restore, want false")
+	}
+}
+
+func TestRestoreSystemDNSNoopsWithoutGecitMarker(t *testing.T) {
+	const original = "nameserver 127.0.0.1\nsearch local\n"
+	path := withTestResolvConf(t, original)
+
+	if err := RestoreSystemDNS(); err != nil {
+		t.Fatalf("RestoreSystemDNS: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read resolv.conf: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("RestoreSystemDNS changed unmanaged file:\n got %q\nwant %q", string(got), original)
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+#
+# gecit installer
+#
+# One-line install:
+#   curl -fsSL https://raw.githubusercontent.com/boratanrikulu/gecit/main/scripts/install.sh | sudo bash
+#
+# Pinned version:
+#   curl -fsSL .../install.sh | sudo VERSION=v0.1.4 bash
+#
+# Skip auto-start:
+#   curl -fsSL .../install.sh | sudo bash -s -- --no-start
+#
+# Uninstall:
+#   curl -fsSL .../install.sh | sudo bash -s -- --uninstall
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REPO="boratanrikulu/gecit"
+PREFIX="${PREFIX:-/usr/local}"
+BIN_DIR="${PREFIX}/bin"
+BIN_PATH="${BIN_DIR}/gecit"
+UNIT_PATH="/etc/systemd/system/gecit.service"
+MIN_KERNEL_MAJOR=5
+MIN_KERNEL_MINOR=10
+
+# ---------------------------------------------------------------------------
+# Output helpers (ANSI only, matches scripts/demo.sh style)
+# ---------------------------------------------------------------------------
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    CYAN='\033[0;36m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED='' GREEN='' YELLOW='' CYAN='' BOLD='' NC=''
+fi
+
+step() { printf "\n  ${BOLD}[%s/%s]${NC} %s\n" "$1" "$2" "$3"; }
+ok()   { printf "  ${GREEN}OK${NC}   %s\n" "$*"; }
+info() { printf "  ${CYAN}..${NC}   %s\n" "$*"; }
+warn() { printf "  ${YELLOW}WARN${NC} %s\n" "$*"; }
+err()  { printf "\n  ${RED}ERROR${NC} %s\n\n" "$*" >&2; exit 1; }
+
+usage() {
+    cat <<'EOF'
+gecit installer
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/boratanrikulu/gecit/main/scripts/install.sh | sudo bash
+  curl -fsSL .../install.sh | sudo bash -s -- [flags]
+
+Flags:
+  --no-start       install but don't start the service
+  --no-enable      install but don't enable or start the service
+  --uninstall      stop, disable, and remove gecit
+  -h, --help       show this help
+
+Environment:
+  VERSION=vX.Y.Z   pin to a specific release (default: latest)
+  PREFIX=/path     install root (default: /usr/local; binary at $PREFIX/bin/gecit)
+  NO_COLOR=1       disable ANSI colors
+
+EOF
+    exit "${1:-0}"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+NO_START=0
+NO_ENABLE=0
+UNINSTALL=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --no-start)   NO_START=1 ;;
+        --no-enable)  NO_ENABLE=1; NO_START=1 ;;
+        --uninstall)  UNINSTALL=1 ;;
+        -h|--help)    usage 0 ;;
+        *)            printf "Unknown flag: %s\n\n" "$1" >&2; usage 1 ;;
+    esac
+    shift
+done
+
+# ---------------------------------------------------------------------------
+# Root check
+# ---------------------------------------------------------------------------
+
+if [ "$(id -u)" -ne 0 ]; then
+    err "Must run as root. Re-run with:
+    curl -fsSL https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh | sudo bash"
+fi
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux) OS=linux ;;
+        *) err "Only Linux is supported by this installer (got $(uname -s)). See README for macOS/Windows setup." ;;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)  ARCH=amd64 ;;
+        aarch64|arm64) ARCH=arm64 ;;
+        *) err "Unsupported architecture: $(uname -m). Supported: amd64, arm64." ;;
+    esac
+}
+
+detect_kernel() {
+    local kver major minor
+    kver="$(uname -r)"
+    major="${kver%%.*}"
+    minor="${kver#*.}"; minor="${minor%%.*}"
+    if [ "$major" -lt "$MIN_KERNEL_MAJOR" ] || \
+       { [ "$major" -eq "$MIN_KERNEL_MAJOR" ] && [ "$minor" -lt "$MIN_KERNEL_MINOR" ]; }; then
+        err "gecit needs Linux kernel ${MIN_KERNEL_MAJOR}.${MIN_KERNEL_MINOR}+ for eBPF sock_ops (you have ${kver})."
+    fi
+}
+
+detect_systemd() {
+    if [ ! -d /run/systemd/system ]; then
+        err "systemd not detected (no /run/systemd/system). This installer only configures systemd."
+    fi
+}
+
+require_tools() {
+    local missing=()
+    for t in curl sha256sum install systemctl awk; do
+        command -v "$t" >/dev/null 2>&1 || missing+=("$t")
+    done
+    if [ "${#missing[@]}" -gt 0 ]; then
+        err "Missing required tools: ${missing[*]}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Version resolution
+# ---------------------------------------------------------------------------
+
+resolve_version() {
+    if [ -n "${VERSION:-}" ]; then
+        info "Using pinned version: ${VERSION}"
+        return
+    fi
+    info "Resolving latest release from GitHub..."
+    local resp
+    if ! resp="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest")"; then
+        err "Could not reach GitHub API. Set VERSION=vX.Y.Z to pin manually."
+    fi
+    if [[ "$resp" =~ \"tag_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+        VERSION="${BASH_REMATCH[1]}"
+    else
+        err "Could not parse release tag from GitHub response. Set VERSION=vX.Y.Z to pin manually."
+    fi
+    info "Latest release: ${VERSION}"
+}
+
+# ---------------------------------------------------------------------------
+# Existing install handling
+# ---------------------------------------------------------------------------
+
+backup_existing() {
+    local found=0
+    if systemctl is-active --quiet gecit 2>/dev/null; then
+        info "Stopping running gecit service..."
+        systemctl stop gecit
+        found=1
+    fi
+    if [ -f "$UNIT_PATH" ]; then
+        info "Backing up existing unit to ${UNIT_PATH}.bak"
+        cp -p "$UNIT_PATH" "${UNIT_PATH}.bak"
+        found=1
+    fi
+    if [ -f "$BIN_PATH" ]; then
+        info "Backing up existing binary to ${BIN_PATH}.bak"
+        cp -p "$BIN_PATH" "${BIN_PATH}.bak"
+        found=1
+    fi
+    if [ "$found" -eq 0 ]; then
+        info "No existing install found"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Download + verify
+# ---------------------------------------------------------------------------
+
+download_and_verify() {
+    TMPDIR="$(mktemp -d -t gecit-install.XXXXXX)"
+    trap 'rm -rf "$TMPDIR"' EXIT
+
+    local asset="gecit-${OS}-${ARCH}"
+    local bin_url="https://github.com/${REPO}/releases/download/${VERSION}/${asset}"
+    local sum_url="https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt"
+
+    info "Downloading ${asset}..."
+    if ! curl -fsSL --proto '=https' --tlsv1.2 -o "${TMPDIR}/gecit" "$bin_url"; then
+        err "Failed to download ${bin_url}. Check that release ${VERSION} has a ${asset} asset."
+    fi
+
+    info "Downloading checksums.txt..."
+    if ! curl -fsSL --proto '=https' --tlsv1.2 -o "${TMPDIR}/checksums.txt" "$sum_url"; then
+        err "Failed to download ${sum_url}."
+    fi
+
+    info "Verifying SHA256..."
+    local expected actual
+    # Upstream checksums.txt entries can be either "<sha>  <asset>" or
+    # "<sha>  <subdir>/<asset>". Match either form on the last field.
+    expected="$(awk -v f="$asset" '$NF == f || $NF ~ ("/"f"$") { print $1; exit }' "${TMPDIR}/checksums.txt")"
+    if [ -z "$expected" ]; then
+        err "No checksum entry for ${asset} in checksums.txt."
+    fi
+    actual="$(sha256sum "${TMPDIR}/gecit" | awk '{print $1}')"
+    if [ "$expected" != "$actual" ]; then
+        err "Checksum mismatch for ${asset}.
+    expected: ${expected}
+    actual:   ${actual}"
+    fi
+    ok "Checksum verified"
+}
+
+# ---------------------------------------------------------------------------
+# Install
+# ---------------------------------------------------------------------------
+
+install_binary() {
+    install -d -m 0755 "$BIN_DIR"
+    install -m 0755 "${TMPDIR}/gecit" "$BIN_PATH"
+    ok "Installed binary at ${BIN_PATH}"
+}
+
+write_unit() {
+    cat > "$UNIT_PATH" <<EOF
+[Unit]
+Description=gecit DPI bypass (eBPF)
+Documentation=https://github.com/${REPO}
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${BIN_PATH} run
+ExecStopPost=${BIN_PATH} cleanup
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    chmod 0644 "$UNIT_PATH"
+    ok "Wrote systemd unit at ${UNIT_PATH}"
+}
+
+activate_service() {
+    systemctl daemon-reload
+    if [ "$NO_ENABLE" -eq 1 ]; then
+        info "Skipping enable + start (--no-enable)"
+        return
+    fi
+    systemctl enable gecit >/dev/null 2>&1 || warn "systemctl enable returned non-zero"
+    ok "Service enabled"
+    if [ "$NO_START" -eq 1 ]; then
+        info "Skipping start (--no-start)"
+        return
+    fi
+    if ! systemctl start gecit 2>/dev/null; then
+        warn "systemctl start gecit failed. Check: journalctl -u gecit -n 50"
+        return
+    fi
+    sleep 1
+    if systemctl is-active --quiet gecit; then
+        ok "Service active"
+    else
+        warn "Service did not become active. Check: journalctl -u gecit -n 50"
+    fi
+}
+
+print_install_summary() {
+    local active
+    active="$(systemctl is-active gecit 2>/dev/null || true)"
+    [ -z "$active" ] && active="not running"
+    printf "\n"
+    printf "  %sgecit %s installed%s\n" "$BOLD" "$VERSION" "$NC"
+    printf "  ----------------------------------------\n"
+    printf "  binary:   %s\n" "$BIN_PATH"
+    printf "  unit:     %s\n" "$UNIT_PATH"
+    printf "  status:   %s\n" "$active"
+    printf "\n"
+    printf "  %sCommon commands%s\n" "$BOLD" "$NC"
+    printf "    sudo systemctl status gecit\n"
+    printf "    sudo systemctl restart gecit\n"
+    printf "    sudo journalctl -u gecit -f\n"
+    printf "    sudo gecit status\n"
+    printf "\n"
+    printf "  %sCustomize flags%s (--fake-ttl, --doh-upstream, --ports, ...)\n" "$BOLD" "$NC"
+    printf "    sudo systemctl edit gecit\n"
+    printf "\n"
+    printf "  %sUninstall%s\n" "$BOLD" "$NC"
+    printf "    curl -fsSL https://raw.githubusercontent.com/%s/main/scripts/install.sh | sudo bash -s -- --uninstall\n" "$REPO"
+    printf "\n"
+}
+
+# ---------------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------------
+
+run_uninstall() {
+    info "Uninstalling gecit..."
+    if systemctl is-active --quiet gecit 2>/dev/null; then
+        info "Stopping service (ExecStopPost runs gecit cleanup to restore DNS state)..."
+        systemctl stop gecit
+    elif [ -x "$BIN_PATH" ]; then
+        info "Service not running; invoking gecit cleanup directly..."
+        "$BIN_PATH" cleanup || warn "gecit cleanup returned non-zero (may be benign)"
+    fi
+    if systemctl is-enabled --quiet gecit 2>/dev/null; then
+        systemctl disable gecit >/dev/null 2>&1 || true
+    fi
+    rm -f "$UNIT_PATH" "${UNIT_PATH}.bak"
+    rm -f "$BIN_PATH" "${BIN_PATH}.bak"
+    systemctl daemon-reload
+    ok "gecit removed"
+    printf "\n"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    printf "\n  %sgecit installer%s\n" "$BOLD" "$NC"
+    printf "  ----------------------------------------\n"
+
+    if [ "$UNINSTALL" -eq 1 ]; then
+        run_uninstall
+        return
+    fi
+
+    step 1 7 "Preflight"
+    detect_os
+    detect_arch
+    detect_kernel
+    detect_systemd
+    require_tools
+    ok "${OS}/${ARCH}, kernel $(uname -r), systemd present"
+
+    step 2 7 "Resolve version"
+    resolve_version
+
+    step 3 7 "Download and verify"
+    download_and_verify
+
+    step 4 7 "Back up existing install (if any)"
+    backup_existing
+
+    step 5 7 "Install binary"
+    install_binary
+
+    step 6 7 "Write systemd unit"
+    write_unit
+
+    step 7 7 "Activate service"
+    activate_service
+
+    print_install_summary
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Two related changes that together make `gecit` install-and-go on Linux:

1. **One-line installer** at `scripts/install.sh`:

   ```bash
   curl -fsSL https://raw.githubusercontent.com/boratanrikulu/gecit/main/scripts/install.sh | sudo bash
   ```

2. **Fix `gecit cleanup` on Linux** — was a no-op (`platformCleanup` returned `false`), so the system DNS state set by `SetSystemDNS` was never undone. Now actually restores `/etc/resolv.conf`. Required for the installer's `--uninstall` path (and any normal stop, crash recovery, or `Ctrl+C`) to do what the README promises.

## Installer (`scripts/install.sh`)

Handles preflight (OS / arch / kernel ≥ 5.10 / systemd present), backs up any existing install, downloads the release binary, **verifies SHA256 against the published `checksums.txt`**, writes a vanilla systemd unit, then enables and starts the service.

Supports:

- `--uninstall` — stops, disables, runs `gecit cleanup`, removes binary + unit
- `--no-start` — install but don't start
- `--no-enable` — install but don't enable or start
- `VERSION=vX.Y.Z` — pin to a specific release
- `PREFIX=/path` — install root (default `/usr/local`)
- `NO_COLOR=1` — disable ANSI colors

### Generated systemd unit

```ini
[Unit]
Description=gecit DPI bypass (eBPF)
Documentation=https://github.com/boratanrikulu/gecit
After=network-online.target
Wants=network-online.target

[Service]
Type=simple
ExecStart=/usr/local/bin/gecit run
ExecStopPost=/usr/local/bin/gecit cleanup
Restart=on-failure
RestartSec=5

[Install]
WantedBy=multi-user.target
```

`ExecStopPost=gecit cleanup` ensures DNS state is restored on stop or crash — which now actually works thanks to the second half of this PR. Custom flags via `sudo systemctl edit gecit`.

## Linux cleanup fix

`cmd/gecit/app/cleanup_linux.go`'s `platformCleanup()` was hardcoded `return false`, so `gecit cleanup` couldn't restore `/etc/resolv.conf` after a crash or normal stop. With this PR:

- `platformCleanup()` checks for gecit-managed state in `/etc/resolv.conf` and restores it via `RestoreSystemDNS` if present
- `pkg/dns/system_linux.go` adds `SystemDNSNeedsRestore()` and a `hasGecitDNSState()` helper; `RestoreSystemDNS` is now idempotent (no-op when no gecit markers exist)
- `resolvConf` `const` → `resolvConfPath` `var` so tests can inject a temp path
- `pkg/dns/system_linux_test.go` (new) — covers happy-path restore and the no-marker no-op

## Files changed

| File | Change |
|---|---|
| `scripts/install.sh` | new, ~380 lines bash, shellcheck-clean |
| `README.md` | adds "Quick install (Linux, recommended)" subsection above existing manual instructions; existing manual block kept intact |
| `cmd/gecit/app/cleanup_linux.go` | wire `platformCleanup` to restore DNS via `pkg/dns` |
| `pkg/dns/system_linux.go` | add idempotency + `SystemDNSNeedsRestore` probe; testable path var |
| `pkg/dns/system_linux_test.go` | new tests for DNS restore |

## Test plan

- [x] `bash -n scripts/install.sh` — syntax clean
- [x] `shellcheck scripts/install.sh` — no findings
- [x] `systemd-analyze verify` on generated unit — exit 0
- [x] End-to-end install + uninstall in a fresh Fedora systemd container (`podman run --systemd=always --privileged`)
- [x] `--help`, unknown-flag, and non-root error paths exercised
- [x] New Linux DNS restore tests pass under `go test ./pkg/dns/...`

Happy to address feedback on default flags, unit hardening, error messages, or scope.